### PR TITLE
feat: add regex log watch alerts for managed processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ pi install git:github.com/aliou/pi-processes
 process start "pnpm dev" name="backend-dev"
 process start "pnpm build" name="build" alertOnSuccess=true
 process start "pnpm test" alertOnFailure=true
+process start "pnpm dev" name="web" logWatches=[{ pattern: "ready on port \\d+", flags: "i", stream: "stdout" }]
 process list
 process output id="backend"
 process logs id="proc_1"
@@ -48,6 +49,11 @@ process clear
 - `alertOnSuccess` (default: false) - Get a turn to react when process completes successfully. Use for builds/tests where you need confirmation.
 - `alertOnFailure` (default: true) - Get a turn to react when process fails/crashes. Use to be alerted of unexpected failures.
 - `alertOnKill` (default: false) - Get a turn to react if killed by external signal. Note: killing via tool never triggers a turn.
+- `logWatches` - Watch complete stdout/stderr lines for regex matches. Matching lines are shown in the UI and trigger an agent turn.
+  - `pattern` - Regex pattern string
+  - `flags` (optional) - Regex flags, e.g. `i`
+  - `stream` (optional, default: `both`) - `stdout`, `stderr`, or `both`
+  - `once` (optional, default: true) - Stop alerting after the first match for that watch
 
 **Important:** You don't need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work - you'll be informed if something requires attention.
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,9 +4,16 @@ export type {
   ManagerEvent,
   ProcessesDetails,
   ProcessInfo,
+  ProcessLogMatch,
+  ProcessLogWatch,
+  ProcessLogWatchStream,
   ProcessStatus,
   StartOptions,
   WriteResult,
 } from "./types";
 
-export { LIVE_STATUSES, MESSAGE_TYPE_PROCESS_UPDATE } from "./types";
+export {
+  LIVE_STATUSES,
+  MESSAGE_TYPE_PROCESS_LOG_MATCH,
+  MESSAGE_TYPE_PROCESS_UPDATE,
+} from "./types";

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,5 +1,23 @@
 // Custom message type for process update notifications
 export const MESSAGE_TYPE_PROCESS_UPDATE = "ad-process:update";
+export const MESSAGE_TYPE_PROCESS_LOG_MATCH = "ad-process:log-match";
+
+export type ProcessLogWatchStream = "stdout" | "stderr" | "both";
+
+export interface ProcessLogWatch {
+  pattern: string;
+  flags?: string;
+  stream?: ProcessLogWatchStream;
+  once?: boolean;
+}
+
+export interface ProcessLogMatch {
+  stream: "stdout" | "stderr";
+  line: string;
+  pattern: string;
+  flags: string;
+  matchCount: number;
+}
 
 export type ProcessStatus =
   | "running"
@@ -35,6 +53,7 @@ export interface ProcessInfo {
 export type ManagerEvent =
   | { type: "process_started"; info: ProcessInfo }
   | { type: "process_ended"; info: ProcessInfo }
+  | { type: "process_log_matched"; info: ProcessInfo; match: ProcessLogMatch }
   | { type: "processes_changed" };
 
 export type KillResult =
@@ -52,6 +71,7 @@ export interface StartOptions {
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: ProcessLogWatch[];
 }
 
 export interface ProcessesDetails {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ import { setupBackgroundBlocker } from "./background-blocker";
 import { setupCleanupHook } from "./cleanup";
 import { setupMessageRenderer } from "./message-renderer";
 import { setupProcessEndHook } from "./process-end";
+import { setupProcessLogWatchHook } from "./process-log-watch";
 import { type DockActions, setupProcessWidget } from "./widget";
 
 export type { DockActions };
@@ -16,6 +17,7 @@ export function setupProcessesHooks(
 ): { update: () => void; dockActions: DockActions } {
   setupCleanupHook(pi, manager);
   setupProcessEndHook(pi, manager);
+  setupProcessLogWatchHook(pi, manager);
 
   if (config.interception.blockBackgroundCommands) {
     setupBackgroundBlocker(pi);

--- a/src/hooks/message-renderer.ts
+++ b/src/hooks/message-renderer.ts
@@ -4,7 +4,10 @@ import type {
   Theme,
 } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
-import { MESSAGE_TYPE_PROCESS_UPDATE } from "../constants";
+import {
+  MESSAGE_TYPE_PROCESS_LOG_MATCH,
+  MESSAGE_TYPE_PROCESS_UPDATE,
+} from "../constants";
 
 interface ProcessUpdateDetails {
   processId: string;
@@ -16,10 +19,22 @@ interface ProcessUpdateDetails {
   runtime: string;
 }
 
-interface ProcessUpdateMessage {
+interface ProcessLogMatchDetails {
+  processId: string;
+  processName: string;
+  command: string;
+  stream: "stdout" | "stderr";
+  line: string;
+  pattern: string;
+  flags: string;
+  matchCount: number;
+  runtime: string;
+}
+
+interface ProcessMessage<TDetails> {
   customType: string;
   content: string | Array<{ type: string; text?: string }>;
-  details?: ProcessUpdateDetails;
+  details?: TDetails;
 }
 
 function getContentText(
@@ -38,7 +53,7 @@ export function setupMessageRenderer(pi: ExtensionAPI) {
   pi.registerMessageRenderer<ProcessUpdateDetails>(
     MESSAGE_TYPE_PROCESS_UPDATE,
     (
-      message: ProcessUpdateMessage,
+      message: ProcessMessage<ProcessUpdateDetails>,
       _options: MessageRenderOptions,
       theme: Theme,
     ) => {
@@ -76,6 +91,34 @@ export function setupMessageRenderer(pi: ExtensionAPI) {
         " " +
         theme.fg(color, statusText) +
         theme.fg("muted", ` ${details.runtime}`);
+
+      return new Text(text, 0, 0);
+    },
+  );
+
+  pi.registerMessageRenderer<ProcessLogMatchDetails>(
+    MESSAGE_TYPE_PROCESS_LOG_MATCH,
+    (
+      message: ProcessMessage<ProcessLogMatchDetails>,
+      _options: MessageRenderOptions,
+      theme: Theme,
+    ) => {
+      const details = message.details;
+
+      if (!details) {
+        return new Text(getContentText(message.content), 0, 0);
+      }
+
+      const pattern = `/${details.pattern}/${details.flags}`;
+      const text =
+        theme.fg("warning", "! ") +
+        theme.fg("accent", `"${details.processName}"`) +
+        theme.fg("muted", ` (${details.processId})`) +
+        " " +
+        theme.fg("warning", `matched ${pattern}`) +
+        theme.fg("muted", ` ${details.stream} ${details.runtime}`) +
+        " " +
+        details.line;
 
       return new Text(text, 0, 0);
     },

--- a/src/hooks/process-log-watch.ts
+++ b/src/hooks/process-log-watch.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { MESSAGE_TYPE_PROCESS_LOG_MATCH } from "../constants";
+import type { ProcessManager } from "../manager";
+import { formatRuntime } from "../utils";
+
+interface ProcessLogMatchDetails {
+  processId: string;
+  processName: string;
+  command: string;
+  stream: "stdout" | "stderr";
+  line: string;
+  pattern: string;
+  flags: string;
+  matchCount: number;
+  runtime: string;
+}
+
+function truncateLine(line: string, max = 200): string {
+  if (line.length <= max) {
+    return line;
+  }
+  return `${line.slice(0, max - 1)}…`;
+}
+
+export function setupProcessLogWatchHook(
+  pi: ExtensionAPI,
+  manager: ProcessManager,
+) {
+  manager.onEvent((event) => {
+    if (event.type !== "process_log_matched") return;
+
+    const runtime = formatRuntime(event.info.startTime, Date.now());
+    const line = truncateLine(event.match.line);
+    const pattern = `/${event.match.pattern}/${event.match.flags}`;
+    const streamLabel = event.match.stream === "stderr" ? "stderr" : "stdout";
+    const message = `Process '${event.info.name}' matched log watch ${pattern} on ${streamLabel}: ${line}`;
+
+    const details: ProcessLogMatchDetails = {
+      processId: event.info.id,
+      processName: event.info.name,
+      command: event.info.command,
+      stream: event.match.stream,
+      line,
+      pattern: event.match.pattern,
+      flags: event.match.flags,
+      matchCount: event.match.matchCount,
+      runtime,
+    };
+
+    pi.sendMessage(
+      {
+        customType: MESSAGE_TYPE_PROCESS_LOG_MATCH,
+        content: message,
+        display: true,
+        details,
+      },
+      { triggerTurn: true },
+    );
+  });
+}

--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -1,0 +1,113 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { type ManagerEvent, ProcessManager } from "./manager";
+
+function resolveTestShell(): string {
+  const candidates = [
+    "/run/current-system/sw/bin/bash",
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/usr/local/bin/bash",
+  ];
+
+  const shell = candidates.find((candidate) => existsSync(candidate));
+  if (!shell) {
+    throw new Error("Unable to resolve bash for manager tests");
+  }
+
+  return shell;
+}
+
+function waitForEvent<T extends ManagerEvent>(
+  manager: ProcessManager,
+  predicate: (event: ManagerEvent) => event is T,
+  timeoutMs = 3000,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(
+        new Error(`Timed out waiting for manager event after ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+
+    const unsubscribe = manager.onEvent((event) => {
+      if (!predicate(event)) return;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(event);
+    });
+  });
+}
+
+describe("ProcessManager log watches", () => {
+  it("emits process_log_matched when a stdout line matches a configured log watch", async () => {
+    const manager = new ProcessManager({
+      getConfiguredShellPath: () => resolveTestShell(),
+    });
+
+    try {
+      const matchPromise = waitForEvent(
+        manager,
+        (
+          event,
+        ): event is Extract<ManagerEvent, { type: "process_log_matched" }> =>
+          event.type === "process_log_matched",
+      );
+
+      manager.start("watch-test", "printf 'server ready\\n'", process.cwd(), {
+        logWatches: [{ pattern: "server ready", stream: "stdout" }],
+      });
+
+      const event = await matchPromise;
+
+      expect(event.info.name).toBe("watch-test");
+      expect(event.match.stream).toBe("stdout");
+      expect(event.match.line).toBe("server ready");
+      expect(event.match.pattern).toBe("server ready");
+      expect(event.match.matchCount).toBe(1);
+    } finally {
+      manager.cleanup();
+    }
+  });
+
+  it("matches each watch only once by default", async () => {
+    const manager = new ProcessManager({
+      getConfiguredShellPath: () => resolveTestShell(),
+    });
+    const matches: Array<
+      Extract<ManagerEvent, { type: "process_log_matched" }>
+    > = [];
+
+    try {
+      const endPromise = waitForEvent(
+        manager,
+        (event): event is Extract<ManagerEvent, { type: "process_ended" }> =>
+          event.type === "process_ended",
+      );
+
+      const unsubscribe = manager.onEvent((event) => {
+        if (event.type === "process_log_matched") {
+          matches.push(event);
+        }
+      });
+
+      manager.start(
+        "watch-once-test",
+        "printf 'ready\\nready\\n'",
+        process.cwd(),
+        {
+          logWatches: [{ pattern: "ready", stream: "stdout" }],
+        },
+      );
+
+      await endPromise;
+      unsubscribe();
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.match.matchCount).toBe(1);
+    } finally {
+      manager.cleanup();
+    }
+  });
+});

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -16,12 +16,23 @@ import {
   LIVE_STATUSES,
   type ManagerEvent,
   type ProcessInfo,
+  type ProcessLogWatch,
+  type ProcessLogWatchStream,
   type ProcessStatus,
   type StartOptions,
   type WriteResult,
 } from "./constants";
-import { isProcessGroupAlive, killProcessGroup } from "./utils";
+import { isProcessGroupAlive, killProcessGroup, stripAnsi } from "./utils";
 import { spawnCommand } from "./utils/command-executor";
+
+interface ManagedLogWatch {
+  pattern: string;
+  flags: string;
+  stream: ProcessLogWatchStream;
+  once: boolean;
+  regex: RegExp;
+  matchCount: number;
+}
 
 interface ManagedProcess extends ProcessInfo {
   process: ChildProcess;
@@ -29,6 +40,9 @@ interface ManagedProcess extends ProcessInfo {
   stdinClosed: boolean;
   lastSignalSent: NodeJS.Signals | null;
   combinedFile: string;
+  stdoutRemainder: string;
+  stderrRemainder: string;
+  logWatches: ManagedLogWatch[];
 }
 
 interface ProcessManagerOptions {
@@ -110,12 +124,95 @@ export class ProcessManager {
       if (managed.lastSignalSent) {
         managed.success = false;
         managed.exitCode = null;
+        this.flushPendingLines(managed);
         this.transition(managed, "killed");
       } else {
         managed.success = false;
         managed.exitCode = null;
+        this.flushPendingLines(managed);
         this.transition(managed, "exited");
       }
+    }
+  }
+
+  private createLogWatches(logWatches?: ProcessLogWatch[]): ManagedLogWatch[] {
+    return (logWatches ?? []).map((watch) => ({
+      pattern: watch.pattern,
+      flags: watch.flags ?? "",
+      stream: watch.stream ?? "both",
+      once: watch.once ?? true,
+      regex: new RegExp(watch.pattern, watch.flags ?? ""),
+      matchCount: 0,
+    }));
+  }
+
+  private handleChunk(
+    managed: ManagedProcess,
+    stream: "stdout" | "stderr",
+    chunk: string,
+  ): void {
+    const previous =
+      stream === "stdout" ? managed.stdoutRemainder : managed.stderrRemainder;
+    const combined = previous + chunk;
+    const parts = combined.split("\n");
+    const remainder = parts.pop() ?? "";
+
+    if (stream === "stdout") {
+      managed.stdoutRemainder = remainder;
+    } else {
+      managed.stderrRemainder = remainder;
+    }
+
+    for (const line of parts) {
+      this.handleLine(managed, stream, line);
+    }
+  }
+
+  private flushPendingLines(managed: ManagedProcess): void {
+    if (managed.stdoutRemainder) {
+      this.handleLine(managed, "stdout", managed.stdoutRemainder);
+      managed.stdoutRemainder = "";
+    }
+
+    if (managed.stderrRemainder) {
+      this.handleLine(managed, "stderr", managed.stderrRemainder);
+      managed.stderrRemainder = "";
+    }
+  }
+
+  private handleLine(
+    managed: ManagedProcess,
+    stream: "stdout" | "stderr",
+    line: string,
+  ): void {
+    const cleanLine = stripAnsi(line.replace(/\r$/, ""));
+
+    for (const watch of managed.logWatches) {
+      if (watch.stream !== "both" && watch.stream !== stream) {
+        continue;
+      }
+      if (watch.once && watch.matchCount > 0) {
+        continue;
+      }
+
+      watch.regex.lastIndex = 0;
+      if (!watch.regex.test(cleanLine)) {
+        continue;
+      }
+
+      watch.matchCount += 1;
+      watch.regex.lastIndex = 0;
+      this.emit({
+        type: "process_log_matched",
+        info: this.toProcessInfo(managed),
+        match: {
+          stream,
+          line: cleanLine,
+          pattern: watch.pattern,
+          flags: watch.flags,
+          matchCount: watch.matchCount,
+        },
+      });
     }
   }
 
@@ -134,6 +231,7 @@ export class ProcessManager {
     appendFileSync(stderrFile, "");
     appendFileSync(combinedFile, "");
 
+    const managedLogWatches = this.createLogWatches(options?.logWatches);
     const child = spawnCommand(command, cwd, this.getConfiguredShellPath());
 
     child.unref();
@@ -159,6 +257,9 @@ export class ProcessManager {
       stdin: child.stdin,
       stdinClosed: false,
       lastSignalSent: null,
+      stdoutRemainder: "",
+      stderrRemainder: "",
+      logWatches: managedLogWatches,
     };
 
     this.processes.set(id, managed);
@@ -179,7 +280,8 @@ export class ProcessManager {
     child.stdout?.on("data", (data: Buffer) => {
       try {
         appendFileSync(stdoutFile, data);
-        const lines = data.toString().split("\n");
+        const text = data.toString();
+        const lines = text.split("\n");
         // The last element after split is either empty (if data ended with \n)
         // or a partial line. We write all parts with the prefix and newline.
         const tagged = lines
@@ -188,6 +290,7 @@ export class ProcessManager {
           )
           .join("");
         if (tagged) appendFileSync(combinedFile, tagged);
+        this.handleChunk(managed, "stdout", text);
       } catch {
         // Ignore
       }
@@ -196,13 +299,15 @@ export class ProcessManager {
     child.stderr?.on("data", (data: Buffer) => {
       try {
         appendFileSync(stderrFile, data);
-        const lines = data.toString().split("\n");
+        const text = data.toString();
+        const lines = text.split("\n");
         const tagged = lines
           .map((line, i) =>
             i < lines.length - 1 ? `2:${line}\n` : line ? `2:${line}\n` : "",
           )
           .join("");
         if (tagged) appendFileSync(combinedFile, tagged);
+        this.handleChunk(managed, "stderr", text);
       } catch {
         // Ignore
       }
@@ -214,6 +319,7 @@ export class ProcessManager {
       managed.exitCode = code;
       managed.endTime = Date.now();
       managed.success = code === 0;
+      this.flushPendingLines(managed);
 
       if (signal) {
         this.transition(managed, "killed");
@@ -233,6 +339,7 @@ export class ProcessManager {
         managed.exitCode = -1;
         managed.success = false;
         managed.endTime = Date.now();
+        this.flushPendingLines(managed);
         this.transition(managed, "exited");
       }
     });

--- a/src/tools/actions/index.ts
+++ b/src/tools/actions/index.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { ExecuteResult } from "../../constants";
+import type { ExecuteResult, ProcessLogWatch } from "../../constants";
 import type { ProcessManager } from "../../manager";
 import { executeClear } from "./clear";
 import { executeKill } from "./kill";
@@ -19,6 +19,7 @@ interface ActionParams {
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: ProcessLogWatch[];
 }
 
 export async function executeAction(

--- a/src/tools/actions/start.test.ts
+++ b/src/tools/actions/start.test.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { ProcessManager } from "../../manager";
+import { executeStart } from "./start";
+
+function resolveTestShell(): string {
+  const candidates = [
+    "/run/current-system/sw/bin/bash",
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/usr/local/bin/bash",
+  ];
+
+  const shell = candidates.find((candidate) => existsSync(candidate));
+  if (!shell) {
+    throw new Error("Unable to resolve bash for start action tests");
+  }
+
+  return shell;
+}
+
+describe("executeStart", () => {
+  it("returns a failure result when a log watch regex is invalid", () => {
+    const manager = new ProcessManager({
+      getConfiguredShellPath: () => resolveTestShell(),
+    });
+
+    try {
+      const result = executeStart(
+        {
+          name: "bad-watch",
+          command: "printf 'noop\\n'",
+          logWatches: [{ pattern: "(", stream: "stdout" }],
+        },
+        manager,
+        { cwd: process.cwd() } as ExtensionContext,
+      );
+
+      expect(result.details.success).toBe(false);
+      expect(result.details.message).toMatch(/invalid log watch/i);
+    } finally {
+      manager.cleanup();
+    }
+  });
+});

--- a/src/tools/actions/start.ts
+++ b/src/tools/actions/start.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { ExecuteResult } from "../../constants";
+import type { ExecuteResult, ProcessLogWatch } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
 interface StartParams {
@@ -8,6 +8,7 @@ interface StartParams {
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: ProcessLogWatch[];
 }
 
 export function executeStart(
@@ -36,20 +37,40 @@ export function executeStart(
     };
   }
 
-  const proc = manager.start(params.name, params.command, ctx.cwd, {
-    alertOnSuccess: params.alertOnSuccess,
-    alertOnFailure: params.alertOnFailure,
-    alertOnKill: params.alertOnKill,
-  });
+  try {
+    const proc = manager.start(params.name, params.command, ctx.cwd, {
+      alertOnSuccess: params.alertOnSuccess,
+      alertOnFailure: params.alertOnFailure,
+      alertOnKill: params.alertOnKill,
+      logWatches: params.logWatches,
+    });
 
-  const message = `Started "${proc.name}" (${proc.id}, PID: ${proc.pid})\nLogs: ${proc.stdoutFile}`;
-  return {
-    content: [{ type: "text", text: message }],
-    details: {
-      action: "start",
-      success: true,
-      message,
-      process: proc,
-    },
-  };
+    const watchSummary = params.logWatches?.length
+      ? `\nLog watches: ${params.logWatches.length}`
+      : "";
+    const message = `Started "${proc.name}" (${proc.id}, PID: ${proc.pid})\nLogs: ${proc.stdoutFile}${watchSummary}`;
+    return {
+      content: [{ type: "text", text: message }],
+      details: {
+        action: "start",
+        success: true,
+        message,
+        process: proc,
+      },
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Invalid log watch: ${error.message}`
+        : "Invalid log watch";
+
+    return {
+      content: [{ type: "text", text: message }],
+      details: {
+        action: "start",
+        success: false,
+        message,
+      },
+    };
+  }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -13,6 +13,28 @@ import type { ProcessManager } from "../manager";
 import { formatRuntime, hasAnsi, stripAnsi, truncateCmd } from "../utils";
 import { executeAction } from "./actions";
 
+const LogWatchParams = Type.Object({
+  pattern: Type.String({
+    description: "Regex pattern to match against complete log lines",
+  }),
+  flags: Type.Optional(
+    Type.String({
+      description: "Regex flags passed to RegExp (optional, e.g. 'i' or 'gm')",
+    }),
+  ),
+  stream: Type.Optional(
+    StringEnum(["stdout", "stderr", "both"] as const, {
+      description: "Which stream to watch (default: both)",
+    }),
+  ),
+  once: Type.Optional(
+    Type.Boolean({
+      description:
+        "Stop alerting after the first match for this watch (default: true)",
+    }),
+  ),
+});
+
 const ProcessesParams = Type.Object({
   action: StringEnum(
     ["start", "list", "output", "logs", "kill", "clear", "write"] as const,
@@ -65,6 +87,12 @@ const ProcessesParams = Type.Object({
         "Get a turn to react when process is killed by external signal (default: false). Note: killing via tool never triggers a turn.",
     }),
   ),
+  logWatches: Type.Optional(
+    Type.Array(LogWatchParams, {
+      description:
+        "Watch complete stdout/stderr lines for regex matches. Matching lines are shown in the UI and trigger an agent turn.",
+    }),
+  ),
 });
 
 type ProcessesParamsType = Static<typeof ProcessesParams>;
@@ -78,6 +106,7 @@ export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
   - alertOnSuccess (default: false): Get a turn to react when process completes successfully
   - alertOnFailure (default: true): Get a turn to react when process crashes/fails
   - alertOnKill (default: false): Get a turn to react if killed by external signal (killing via tool never triggers a turn)
+  - logWatches: Watch complete stdout/stderr lines for regex matches and trigger an agent turn on match
 - list: Show all managed processes with their IDs and names
 - output: Get recent stdout/stderr (requires 'id' - can be proc_N or name match)
 - logs: Get log file paths to inspect with read tool (requires 'id')
@@ -87,7 +116,7 @@ export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
 
 Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work - you'll be informed if something requires attention.
 
-Note: User always sees process updates in the UI. The notify flags control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`,
+Note: User always sees process updates in the UI. The alert flags and log watches control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`,
 
     parameters: ProcessesParams,
 
@@ -113,6 +142,13 @@ Note: User always sees process updates in the UI. The notify flags control wheth
           } else {
             longArgs.push({ label: "command", value: args.command });
           }
+        }
+
+        if (args.logWatches?.length) {
+          optionArgs.push({
+            label: "logWatches",
+            value: String(args.logWatches.length),
+          });
         }
       }
 


### PR DESCRIPTION
   ## Problem

   The process tool could notify the agent when a process exited, but not when a running process emitted an important log line.

   That made it hard to react to runtime milestones and failures such as:
   - a dev server becoming ready
   - a compiler reporting a specific error
   - a background job logging a fatal condition

   Without log-based alerts, the agent had to poll output or wait for process exit, which is both slower and less reliable.

   ## Solution

   Add first-pass log watches to `process start`.

   A process can now be started with `logWatches`, where each watch includes:
   - `pattern`
   - optional `flags`
   - optional `stream` (`stdout`, `stderr`, or `both`)
   - optional `once` (defaults to `true`)

   Implementation details:
   - output is matched against complete buffered log lines
   - matching a watch emits a new `process_log_matched` manager event
   - the extension sends a visible UI message for the match
   - matching a watch triggers an agent turn immediately
   - invalid regexes are rejected when starting the process

   This keeps the process-end alert model intact while adding a way to react to important runtime events before a process exits.

   ## Example

   ```text
   process start "pnpm dev" name="web" logWatches=[
     { pattern: "ready on port \\d+", flags: "i", stream: "stdout" }
   ]
 ```

 Included changes

 - add logWatches to the process start tool schema
 - add manager support for line-based watch matching
 - add a log-watch hook and message renderer
 - add tests for matching and invalid watch configuration
 - update README examples and docs