### PR TITLE
fix: address review findings for output rendering

### DIFF
--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -15,6 +15,7 @@ function waitForEnd(manager: ProcessManager, id: string): Promise<void> {
 
 function collectEvents(manager: ProcessManager): ManagerEvent[] {
   const events: ManagerEvent[] = [];
+  // Unsubscribe not stored; manager.cleanup() in afterEach clears all listeners.
   manager.onEvent((e) => events.push(e));
   return events;
 }
@@ -75,17 +76,6 @@ describe("process_output_changed", () => {
   it("stdout and stderr share one throttle bucket", async () => {
     manager = new ProcessManager();
 
-    // Single-stream burst
-    const events1 = collectEvents(manager);
-    const info1 = manager.start("single", "seq 1 100", "/tmp");
-    await waitForEnd(manager, info1.id);
-    const singleCount = events1.filter(
-      (e) => e.type === "process_output_changed",
-    ).length;
-
-    manager.cleanup();
-    manager = new ProcessManager();
-
     // Dual-stream burst: writes to both stdout and stderr rapidly
     const events2 = collectEvents(manager);
     const info2 = manager.start(
@@ -98,9 +88,8 @@ describe("process_output_changed", () => {
       (e) => e.type === "process_output_changed",
     ).length;
 
-    // Dual should not be significantly more than single (shared bucket)
-    // Allow 3x tolerance since timing varies
-    expect(dualCount).toBeLessThan(Math.max(singleCount * 3, 20));
+    // Both streams share one throttle bucket, so total events should be low
+    expect(dualCount).toBeLessThan(30);
   });
 
   it("trailing emit fires after burst ends", async () => {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -77,6 +77,9 @@ export class ProcessManager {
       const delay = 100 - elapsed;
       const timeout = setTimeout(() => {
         this.pendingOutputEmit.delete(id);
+        // Invariant: every path that removes a process from `this.processes`
+        // must call `clearOutputChangedState(id)` first, which clears this
+        // timeout. This guard is a safety net, not a primary mechanism.
         if (!this.processes.has(id)) return;
         this.lastOutputEmitAt.set(id, Date.now());
         this.emit({ type: "process_output_changed", id });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    globals: true,
     include: ["src/**/*.test.ts"],
     mockReset: true,
   },


### PR DESCRIPTION
Stacked on #10.

- Document invariant on trailing timer guard in `notifyOutputChanged`
- Replace flaky single-vs-dual stream comparison with fixed `< 30` bound
- Remove redundant `globals: true` from vitest config
- Add comment on intentionally unstored unsubscribe in test helper