### PR TITLE
refactor: move tool rendering into per-action files

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,6 +5,7 @@ export type {
   LogWatchMatchEvent,
   LogWatchStream,
   ManagerEvent,
+  ProcessAction,
   ProcessesDetails,
   ProcessInfo,
   ProcessStatus,

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,6 +1,16 @@
 // Custom message type for process update notifications
 export const MESSAGE_TYPE_PROCESS_UPDATE = "ad-process:update";
 
+export type ProcessAction =
+  | "start"
+  | "list"
+  | "output"
+  | "logs"
+  | "kill"
+  | "clear"
+  | "write"
+  | "debug_preview";
+
 export type ProcessStatus =
   | "running"
   | "terminating"
@@ -80,7 +90,7 @@ export interface StartOptions {
 }
 
 export interface ProcessesDetails {
-  action: string;
+  action: ProcessAction;
   success: boolean;
   message: string;
   process?: ProcessInfo;

--- a/src/tools/actions/debug.ts
+++ b/src/tools/actions/debug.ts
@@ -1,7 +1,23 @@
+import { ToolCallHeader } from "@aliou/pi-utils-ui";
+import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { ExecuteResult, ProcessInfo } from "../../constants";
 
 interface DebugParams {
   preview?: "start" | "list" | "output" | "logs" | "error";
+}
+
+export function renderDebugCall(
+  args: DebugParams,
+  theme: Theme,
+): ToolCallHeader {
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "debug_preview",
+      mainArg: args.preview,
+    },
+    theme,
+  );
 }
 
 function mockProcess(overrides?: Partial<ProcessInfo>): ProcessInfo {

--- a/src/tools/actions/index.ts
+++ b/src/tools/actions/index.ts
@@ -1,4 +1,4 @@
-import { ToolBody } from "@aliou/pi-utils-ui";
+import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
 import type {
   AgentToolResult,
   ExtensionContext,
@@ -97,12 +97,11 @@ export function renderActionCall(
       return renderWriteCall(args, theme);
     case "debug_preview":
       return renderDebugCall(args, theme);
-    case "list":
-    case "clear":
-      // No custom renderCall for these actions
-      return undefined;
     default:
-      return undefined;
+      return new ToolCallHeader(
+        { toolName: "Process", action: args.action },
+        theme,
+      );
   }
 }
 

--- a/src/tools/actions/index.ts
+++ b/src/tools/actions/index.ts
@@ -1,19 +1,30 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { ExecuteResult } from "../../constants";
+import { ToolBody } from "@aliou/pi-utils-ui";
+import type {
+  AgentToolResult,
+  ExtensionContext,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import type {
+  ExecuteResult,
+  ProcessAction,
+  ProcessesDetails,
+} from "../../constants";
 import type { ProcessManager } from "../../manager";
 import { executeClear } from "./clear";
-import { executeDebugPreview } from "./debug";
-import { executeKill } from "./kill";
-import { executeList } from "./list";
-import { executeLogs } from "./logs";
-import { executeOutput } from "./output";
-import { executeStart } from "./start";
-import { executeWrite } from "./write";
+import { executeDebugPreview, renderDebugCall } from "./debug";
+import { executeKill, renderKillCall } from "./kill";
+import { executeList, renderListResult } from "./list";
+import { executeLogs, renderLogsCall, renderLogsResult } from "./logs";
+import { executeOutput, renderOutputCall, renderOutputResult } from "./output";
+import { executeStart, renderStartCall, renderStartResult } from "./start";
+import { executeWrite, renderWriteCall } from "./write";
 
 const DEBUG_PREVIEW_ENABLED = process.env.PI_PROCESSES_DEBUG_PREVIEW === "1";
 
 interface ActionParams {
-  action: string;
+  action: ProcessAction | string;
   command?: string;
   name?: string;
   id?: string;
@@ -61,10 +72,79 @@ export async function executeAction(
       return {
         content: [{ type: "text", text: `Unknown action: ${params.action}` }],
         details: {
-          action: params.action,
+          action: params.action as ProcessAction,
           success: false,
           message: `Unknown action: ${params.action}`,
         },
       };
+  }
+}
+
+export function renderActionCall(
+  args: ActionParams,
+  theme: Theme,
+): Component | undefined {
+  switch (args.action) {
+    case "start":
+      return renderStartCall(args, theme);
+    case "output":
+      return renderOutputCall(args, theme);
+    case "logs":
+      return renderLogsCall(args, theme);
+    case "kill":
+      return renderKillCall(args, theme);
+    case "write":
+      return renderWriteCall(args, theme);
+    case "debug_preview":
+      return renderDebugCall(args, theme);
+    case "list":
+    case "clear":
+      // No custom renderCall for these actions
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+export function renderActionResult(
+  result: AgentToolResult<ProcessesDetails>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+): Component | undefined {
+  const { details } = result;
+
+  if (!details) {
+    return undefined;
+  }
+
+  switch (details.action) {
+    case "start":
+      return renderStartResult(result, options, theme);
+    case "list":
+      return renderListResult(result, options, theme);
+    case "output":
+      return renderOutputResult(result, options, theme);
+    case "logs":
+      return renderLogsResult(result, options, theme);
+    case "kill":
+    case "write":
+    case "clear":
+    case "debug_preview":
+      // Default rendering for these actions
+      return new ToolBody(
+        {
+          fields: [
+            {
+              label: "Result",
+              value: details.message,
+              showCollapsed: true,
+            },
+          ],
+        },
+        options,
+        theme,
+      );
+    default:
+      return undefined;
   }
 }

--- a/src/tools/actions/kill.ts
+++ b/src/tools/actions/kill.ts
@@ -1,8 +1,21 @@
+import { ToolCallHeader } from "@aliou/pi-utils-ui";
+import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { ExecuteResult } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
 interface KillParams {
   id?: string;
+}
+
+export function renderKillCall(args: KillParams, theme: Theme): ToolCallHeader {
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "kill",
+      mainArg: args.id,
+    },
+    theme,
+  );
 }
 
 export async function executeKill(

--- a/src/tools/actions/list.ts
+++ b/src/tools/actions/list.ts
@@ -1,4 +1,4 @@
-import { ToolBody } from "@aliou/pi-utils-ui";
+import { ToolBody, ToolFooter } from "@aliou/pi-utils-ui";
 import type {
   AgentToolResult,
   Theme,
@@ -160,5 +160,29 @@ export function renderListResult(
     showCollapsed: true,
   });
 
-  return new ToolBody({ fields }, options, theme);
+  const footerItems: Array<{
+    label: string;
+    value: string;
+  }> = [];
+  if (runningCount > 0) {
+    footerItems.push({ label: "running", value: String(runningCount) });
+  }
+  if (failed > 0) {
+    footerItems.push({ label: "failed", value: String(failed) });
+  }
+  if (killed > 0) {
+    footerItems.push({ label: "killed", value: String(killed) });
+  }
+
+  return new ToolBody(
+    {
+      fields,
+      footer:
+        footerItems.length > 0
+          ? new ToolFooter(theme, { items: footerItems, separator: " | " })
+          : undefined,
+    },
+    options,
+    theme,
+  );
 }

--- a/src/tools/actions/list.ts
+++ b/src/tools/actions/list.ts
@@ -1,6 +1,19 @@
-import type { ExecuteResult } from "../../constants";
+import { ToolBody } from "@aliou/pi-utils-ui";
+import type {
+  AgentToolResult,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import type { ExecuteResult, ProcessesDetails } from "../../constants";
 import type { ProcessManager } from "../../manager";
-import { formatRuntime, formatStatus, truncateCmd } from "../../utils";
+import {
+  formatRuntime,
+  formatStatus,
+  formatStatusTag,
+  formatTimestamp,
+  truncateCmd,
+} from "../../utils";
 
 export function executeList(manager: ProcessManager): ExecuteResult {
   const processes = manager.list();
@@ -34,4 +47,118 @@ export function executeList(manager: ProcessManager): ExecuteResult {
       processes,
     },
   };
+}
+
+export function renderListResult(
+  result: AgentToolResult<ProcessesDetails>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+): ToolBody {
+  const { details } = result;
+
+  if (!details.processes || details.processes.length === 0) {
+    return new ToolBody(
+      {
+        fields: [
+          {
+            label: "Processes",
+            value: "No background processes running",
+            showCollapsed: true,
+          },
+        ],
+      },
+      options,
+      theme,
+    );
+  }
+
+  const processes = [...details.processes];
+
+  const statusRank = (status: string): number => {
+    switch (status) {
+      case "running":
+        return 0;
+      case "terminating":
+        return 1;
+      case "terminate_timeout":
+        return 2;
+      case "killed":
+        return 3;
+      case "exited":
+        return 4;
+      default:
+        return 5;
+    }
+  };
+
+  processes.sort((a, b) => {
+    const rankDiff = statusRank(a.status) - statusRank(b.status);
+    if (rankDiff !== 0) return rankDiff;
+    return b.startTime - a.startTime;
+  });
+
+  const runningCount = processes.filter(
+    (p) => p.status === "running" || p.status === "terminating",
+  ).length;
+
+  const lines: string[] = [
+    theme.fg(
+      "success",
+      `${processes.length} process(es), ${runningCount} running/terminating`,
+    ),
+  ];
+
+  for (const process of processes) {
+    const status = formatStatusTag(process, theme);
+    lines.push(
+      [
+        `- ${theme.fg("accent", process.name)} ${theme.fg("muted", `(${process.id})`)}`,
+        `  pid: ${process.pid}   status: ${status}`,
+        `  started: ${theme.fg("muted", formatTimestamp(process.startTime))}`,
+        `  ended:   ${theme.fg("muted", formatTimestamp(process.endTime))}`,
+        `  runtime: ${theme.fg("muted", formatRuntime(process.startTime, process.endTime))}`,
+      ].join("\n"),
+    );
+  }
+
+  const fields: Array<
+    { label: string; value: string; showCollapsed?: boolean } | Text
+  > = [new Text(lines.join("\n"), 0, 0)];
+
+  const running = details.processes.filter(
+    (p) => p.status === "running" || p.status === "terminating",
+  );
+  const finishedOk = details.processes.filter(
+    (p) => p.status === "exited" && p.success,
+  ).length;
+  const failed = details.processes.filter(
+    (p) => p.status === "exited" && !p.success,
+  ).length;
+  const killed = details.processes.filter((p) => p.status === "killed").length;
+
+  const runningSummary =
+    running.length > 0
+      ? running
+          .slice(0, 3)
+          .map(
+            (p) =>
+              `${theme.fg("accent", `"${p.name}"`)} [${formatStatusTag(p, theme)}]`,
+          )
+          .join(", ")
+      : theme.fg("muted", "no running process");
+
+  const restParts: string[] = [];
+  if (finishedOk > 0) restParts.push(`${finishedOk} finished`);
+  if (failed > 0) restParts.push(`${failed} failed`);
+  if (killed > 0) restParts.push(`${killed} killed`);
+  const restSummary =
+    restParts.length > 0 ? theme.fg("muted", ` + ${restParts.join(", ")}`) : "";
+
+  fields.push({
+    label: "Processes",
+    value: runningSummary + restSummary,
+    showCollapsed: true,
+  });
+
+  return new ToolBody({ fields }, options, theme);
 }

--- a/src/tools/actions/logs.ts
+++ b/src/tools/actions/logs.ts
@@ -1,8 +1,66 @@
-import type { ExecuteResult } from "../../constants";
+import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
+import type {
+  AgentToolResult,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import type { ExecuteResult, ProcessesDetails } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
 interface LogsParams {
   id?: string;
+}
+
+export function renderLogsCall(args: LogsParams, theme: Theme): ToolCallHeader {
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "logs",
+      mainArg: args.id,
+    },
+    theme,
+  );
+}
+
+export function renderLogsResult(
+  result: AgentToolResult<ProcessesDetails>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+): ToolBody {
+  const { details } = result;
+
+  if (!details.logFiles) {
+    return new ToolBody(
+      {
+        fields: [
+          {
+            label: "Error",
+            value: "Missing log file details",
+            showCollapsed: true,
+          },
+        ],
+      },
+      options,
+      theme,
+    );
+  }
+
+  const fields: Array<
+    { label: string; value: string; showCollapsed?: boolean } | Text
+  > = [
+    new Text(
+      [
+        theme.fg("success", "Log files:"),
+        `  stdout: ${theme.fg("accent", details.logFiles.stdoutFile)}`,
+        `  stderr: ${theme.fg("accent", details.logFiles.stderrFile)}`,
+      ].join("\n"),
+      0,
+      0,
+    ),
+  ];
+
+  return new ToolBody({ fields }, options, theme);
 }
 
 export function executeLogs(

--- a/src/tools/actions/output.ts
+++ b/src/tools/actions/output.ts
@@ -1,12 +1,131 @@
+import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
+import type {
+  AgentToolResult,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import { configLoader } from "../../config";
-import type { ExecuteResult } from "../../constants";
+import type { ExecuteResult, ProcessesDetails } from "../../constants";
 import type { ProcessManager } from "../../manager";
-import { formatStatus, stripAnsi } from "../../utils";
+import { formatStatus, hasAnsi, stripAnsi } from "../../utils";
 
 const MAX_BYTES = 50 * 1024; // 50KB
 
 interface OutputParams {
   id?: string;
+}
+
+export function renderOutputCall(
+  args: OutputParams,
+  theme: Theme,
+): ToolCallHeader {
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "output",
+      mainArg: args.id,
+    },
+    theme,
+  );
+}
+
+export function renderOutputResult(
+  result: AgentToolResult<ProcessesDetails>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+): ToolBody {
+  const { details } = result;
+
+  if (!details.output) {
+    return new ToolBody(
+      {
+        fields: [
+          {
+            label: "Error",
+            value: "Missing output details",
+            showCollapsed: true,
+          },
+        ],
+      },
+      options,
+      theme,
+    );
+  }
+
+  const lines: string[] = [theme.fg("muted", details.message)];
+  let hadAnsi = false;
+
+  if (details.output.stdout.length > 0) {
+    lines.push("", theme.fg("accent", "stdout:"));
+    for (const line of details.output.stdout.slice(-20)) {
+      if (!hadAnsi && hasAnsi(line)) hadAnsi = true;
+      lines.push(stripAnsi(line));
+    }
+    if (details.output.stdout.length > 20) {
+      lines.push(
+        theme.fg(
+          "muted",
+          `... (${details.output.stdout.length - 20} more lines)`,
+        ),
+      );
+    }
+  }
+
+  if (details.output.stderr.length > 0) {
+    lines.push("", theme.fg("warning", "stderr:"));
+    for (const line of details.output.stderr.slice(-10)) {
+      if (!hadAnsi && hasAnsi(line)) hadAnsi = true;
+      lines.push(theme.fg("warning", stripAnsi(line)));
+    }
+    if (details.output.stderr.length > 10) {
+      lines.push(
+        theme.fg(
+          "muted",
+          `... (${details.output.stderr.length - 10} more lines)`,
+        ),
+      );
+    }
+  }
+
+  if (details.logFiles) {
+    lines.push(
+      "",
+      theme.fg("success", "Log files:"),
+      `  stdout: ${theme.fg("accent", details.logFiles.stdoutFile)}`,
+      `  stderr: ${theme.fg("accent", details.logFiles.stderrFile)}`,
+    );
+  }
+
+  if (hadAnsi) {
+    lines.push(
+      "",
+      theme.fg("muted", "ANSI escape codes were stripped from output"),
+    );
+  }
+
+  const fields: Array<
+    { label: string; value: string; showCollapsed?: boolean } | Text
+  > = [new Text(lines.join("\n"), 0, 0)];
+
+  // Collapsed summary
+  const previewSource =
+    details.output.stdout.length > 0
+      ? details.output.stdout
+      : details.output.stderr;
+  const preview = previewSource
+    .slice(-2)
+    .map((l) => stripAnsi(l))
+    .join("\n");
+  fields.push({
+    label: "Output",
+    value: preview
+      ? `${theme.fg("muted", preview)}`
+      : theme.fg("muted", "(empty)"),
+    showCollapsed: true,
+  });
+
+  return new ToolBody({ fields }, options, theme);
 }
 
 export function executeOutput(

--- a/src/tools/actions/start.ts
+++ b/src/tools/actions/start.ts
@@ -1,5 +1,12 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import type { ExecuteResult } from "../../constants";
+import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
+import type {
+  AgentToolResult,
+  ExtensionContext,
+  Theme,
+  ToolRenderResultOptions,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import type { ExecuteResult, ProcessesDetails } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
 type WatchStream = "stdout" | "stderr" | "both";
@@ -17,6 +24,100 @@ interface StartParams {
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
   logWatches?: StartLogWatch[];
+}
+
+export function renderStartCall(
+  args: StartParams,
+  theme: Theme,
+): ToolCallHeader {
+  const longArgs: Array<{ label?: string; value: string }> = [];
+  const optionArgs: Array<{ label: string; value: string }> = [];
+  let mainArg: string | undefined;
+
+  if (args.name) {
+    mainArg = `"${args.name}"`;
+  }
+
+  if (args.command) {
+    if (!mainArg && args.command.length <= 60) {
+      mainArg = args.command;
+    } else if (args.command.length <= 60) {
+      optionArgs.push({ label: "command", value: args.command });
+    } else {
+      longArgs.push({ label: "command", value: args.command });
+    }
+  }
+
+  if (args.logWatches && args.logWatches.length > 0) {
+    optionArgs.push({
+      label: "watches",
+      value: String(args.logWatches.length),
+    });
+  }
+
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "start",
+      mainArg,
+      optionArgs,
+      longArgs,
+    },
+    theme,
+  );
+}
+
+export function renderStartResult(
+  result: AgentToolResult<ProcessesDetails>,
+  options: ToolRenderResultOptions,
+  theme: Theme,
+): ToolBody {
+  const { details } = result;
+  const process = details.process;
+
+  if (!process) {
+    return new ToolBody(
+      {
+        fields: [
+          {
+            label: "Error",
+            value: "Missing process details",
+            showCollapsed: true,
+          },
+        ],
+      },
+      options,
+      theme,
+    );
+  }
+
+  const fields: Array<
+    { label: string; value: string; showCollapsed?: boolean } | Text
+  > = [
+    new Text(
+      [
+        theme.fg("success", "Started process"),
+        `  name: ${theme.fg("accent", process.name)}`,
+        `  command: ${process.command}`,
+        `  id: ${theme.fg("accent", process.id)}`,
+        `  pid: ${String(process.pid)}`,
+        "  Log files:",
+        `    - stdout: ${theme.fg("accent", process.stdoutFile)}`,
+        `    - stderr: ${theme.fg("accent", process.stderrFile)}`,
+      ].join("\n"),
+      0,
+      0,
+    ),
+    {
+      label: "Status",
+      value:
+        theme.fg("success", "Started") +
+        ` ${theme.fg("accent", `"${process.name}"`)} (${process.id}, PID: ${process.pid})`,
+      showCollapsed: true,
+    },
+  ];
+
+  return new ToolBody({ fields }, options, theme);
 }
 
 export function executeStart(

--- a/src/tools/actions/write.ts
+++ b/src/tools/actions/write.ts
@@ -1,3 +1,5 @@
+import { ToolCallHeader } from "@aliou/pi-utils-ui";
+import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { ExecuteResult } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
@@ -5,6 +7,30 @@ interface WriteParams {
   id?: string;
   input?: string;
   end?: boolean;
+}
+
+export function renderWriteCall(
+  args: WriteParams,
+  theme: Theme,
+): ToolCallHeader {
+  const optionArgs: Array<{ label: string; value: string }> = [];
+
+  if (args.input) {
+    optionArgs.push({ label: "input", value: args.input });
+    if (args.end) {
+      optionArgs.push({ label: "end", value: "true" });
+    }
+  }
+
+  return new ToolCallHeader(
+    {
+      toolName: "Process",
+      action: "write",
+      mainArg: args.id,
+      optionArgs,
+    },
+    theme,
+  );
 }
 
 export function executeWrite(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -165,19 +165,20 @@ Note: User always sees process updates in the UI. The notify flags control wheth
       options: ToolRenderResultOptions,
       theme: Theme,
     ) {
+      if (options.isPartial) {
+        return new Text(theme.fg("muted", "Process: running..."), 0, 0);
+      }
+
       const { details } = result;
 
-      if (!details) {
-        const message = result.content
-          .map((part) =>
-            part.type === "text" && "text" in part && part.text
-              ? part.text
-              : "",
-          )
-          .join("\n")
-          .trim();
-
-        return new Text(message || "Tool execution failed", 0, 0);
+      // Framework sets details to {} when tool throws.
+      // Detect by checking for missing expected fields.
+      if (!details?.action) {
+        const textBlock = result.content.find((c) => c.type === "text");
+        const errorMsg =
+          (textBlock?.type === "text" && textBlock.text) ||
+          "Tool execution failed";
+        return new Text(theme.fg("error", errorMsg), 0, 0);
       }
 
       if (!details.success) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
+import { ToolBody } from "@aliou/pi-utils-ui";
 import { StringEnum } from "@mariozechner/pi-ai";
 import type {
   AgentToolResult,
@@ -10,8 +10,7 @@ import { Text } from "@mariozechner/pi-tui";
 import { type Static, Type } from "@sinclair/typebox";
 import type { ProcessesDetails } from "../constants";
 import type { ProcessManager } from "../manager";
-import { formatRuntime, hasAnsi, stripAnsi } from "../utils";
-import { executeAction } from "./actions";
+import { executeAction, renderActionCall, renderActionResult } from "./actions";
 
 const DEBUG_PREVIEW_ENABLED = process.env.PI_PROCESSES_DEBUG_PREVIEW === "1";
 
@@ -158,64 +157,7 @@ Note: User always sees process updates in the UI. The notify flags control wheth
     },
 
     renderCall(args: ProcessesParamsType, theme: Theme) {
-      const longArgs: Array<{ label?: string; value: string }> = [];
-      const optionArgs: Array<{ label: string; value: string }> = [];
-      let mainArg: string | undefined;
-
-      if (args.action === "start") {
-        if (args.name) {
-          mainArg = `"${args.name}"`;
-        }
-
-        if (args.command) {
-          if (!mainArg && args.command.length <= 60) {
-            mainArg = args.command;
-          } else if (args.command.length <= 60) {
-            optionArgs.push({ label: "command", value: args.command });
-          } else {
-            longArgs.push({ label: "command", value: args.command });
-          }
-        }
-
-        if (args.logWatches && args.logWatches.length > 0) {
-          optionArgs.push({
-            label: "watches",
-            value: String(args.logWatches.length),
-          });
-        }
-      }
-
-      if (
-        (args.action === "output" ||
-          args.action === "kill" ||
-          args.action === "logs" ||
-          args.action === "write") &&
-        args.id
-      ) {
-        mainArg = args.id;
-      }
-
-      if (args.action === "debug_preview" && args.preview) {
-        mainArg = args.preview;
-      }
-
-      if (args.action === "write" && args.input) {
-        optionArgs.push({ label: "input", value: args.input });
-        if (args.end) {
-          optionArgs.push({ label: "end", value: "true" });
-        }
-      }
-
-      return new ToolCallHeader(
-        {
-          toolName: "Process",
-          action: args.action,
-          mainArg,
-          optionArgs,
-          longArgs,
-        },
-        theme,
-      );
+      return renderActionCall(args, theme);
     },
 
     renderResult(
@@ -238,255 +180,23 @@ Note: User always sees process updates in the UI. The notify flags control wheth
         return new Text(message || "Tool execution failed", 0, 0);
       }
 
-      const fields: Array<
-        { label: string; value: string; showCollapsed?: boolean } | Text
-      > = [];
-
-      const formatTimestamp = (ts: number | null): string => {
-        if (!ts) return "-";
-        return new Date(ts).toISOString().replace("T", " ").slice(0, 19);
-      };
-
-      const formatStatusTag = (process: {
-        status: string;
-        success: boolean | null;
-        exitCode: number | null;
-      }): string => {
-        switch (process.status) {
-          case "running":
-            return theme.fg("accent", "running");
-          case "terminating":
-            return theme.fg("warning", "terminating");
-          case "terminate_timeout":
-            return theme.fg("error", "terminate_timeout");
-          case "killed":
-            return theme.fg("warning", "killed");
-          case "exited":
-            return process.success
-              ? theme.fg("success", "exit(0)")
-              : theme.fg("error", `exit(${process.exitCode ?? "?"})`);
-          default:
-            return theme.fg("muted", process.status);
-        }
-      };
-
       if (!details.success) {
-        fields.push({
-          label: "Error",
-          value: theme.fg("error", details.message),
-          showCollapsed: true,
-        });
-      } else if (details.action === "start" && details.process) {
-        const process = details.process;
-
-        fields.push(
-          new Text(
-            [
-              theme.fg("success", "Started process"),
-              `  name: ${theme.fg("accent", process.name)}`,
-              `  command: ${process.command}`,
-              `  id: ${theme.fg("accent", process.id)}`,
-              `  pid: ${String(process.pid)}`,
-              "  Log files:",
-              `    - stdout: ${theme.fg("accent", process.stdoutFile)}`,
-              `    - stderr: ${theme.fg("accent", process.stderrFile)}`,
-            ].join("\n"),
-            0,
-            0,
-          ),
+        return new ToolBody(
+          {
+            fields: [
+              {
+                label: "Error",
+                value: theme.fg("error", details.message),
+                showCollapsed: true,
+              },
+            ],
+          },
+          options,
+          theme,
         );
-
-        fields.push({
-          label: "Status",
-          value:
-            theme.fg("success", "Started") +
-            ` ${theme.fg("accent", `"${process.name}"`)} (${process.id}, PID: ${process.pid})`,
-          showCollapsed: true,
-        });
-      } else if (details.action === "output" && details.output) {
-        const lines: string[] = [theme.fg("muted", details.message)];
-        let hadAnsi = false;
-
-        if (details.output.stdout.length > 0) {
-          lines.push("", theme.fg("accent", "stdout:"));
-          for (const line of details.output.stdout.slice(-20)) {
-            if (!hadAnsi && hasAnsi(line)) hadAnsi = true;
-            lines.push(stripAnsi(line));
-          }
-          if (details.output.stdout.length > 20) {
-            lines.push(
-              theme.fg(
-                "muted",
-                `... (${details.output.stdout.length - 20} more lines)`,
-              ),
-            );
-          }
-        }
-
-        if (details.output.stderr.length > 0) {
-          lines.push("", theme.fg("warning", "stderr:"));
-          for (const line of details.output.stderr.slice(-10)) {
-            if (!hadAnsi && hasAnsi(line)) hadAnsi = true;
-            lines.push(theme.fg("warning", stripAnsi(line)));
-          }
-          if (details.output.stderr.length > 10) {
-            lines.push(
-              theme.fg(
-                "muted",
-                `... (${details.output.stderr.length - 10} more lines)`,
-              ),
-            );
-          }
-        }
-
-        if (details.logFiles) {
-          lines.push(
-            "",
-            theme.fg("success", "Log files:"),
-            `  stdout: ${theme.fg("accent", details.logFiles.stdoutFile)}`,
-            `  stderr: ${theme.fg("accent", details.logFiles.stderrFile)}`,
-          );
-        }
-
-        if (hadAnsi) {
-          lines.push(
-            "",
-            theme.fg("muted", "ANSI escape codes were stripped from output"),
-          );
-        }
-
-        fields.push(new Text(lines.join("\n"), 0, 0));
-
-        // Collapsed summary
-        const previewSource =
-          details.output.stdout.length > 0
-            ? details.output.stdout
-            : details.output.stderr;
-        const preview = previewSource
-          .slice(-2)
-          .map((l) => stripAnsi(l))
-          .join("\n");
-        fields.push({
-          label: "Output",
-          value: preview
-            ? `${theme.fg("muted", preview)}`
-            : theme.fg("muted", "(empty)"),
-          showCollapsed: true,
-        });
-      } else if (
-        details.action === "list" &&
-        details.processes &&
-        details.processes.length > 0
-      ) {
-        const processes = [...details.processes];
-        const statusRank = (status: string): number => {
-          switch (status) {
-            case "running":
-              return 0;
-            case "terminating":
-              return 1;
-            case "terminate_timeout":
-              return 2;
-            case "killed":
-              return 3;
-            case "exited":
-              return 4;
-            default:
-              return 5;
-          }
-        };
-
-        processes.sort((a, b) => {
-          const rankDiff = statusRank(a.status) - statusRank(b.status);
-          if (rankDiff !== 0) return rankDiff;
-          return b.startTime - a.startTime;
-        });
-
-        const runningCount = processes.filter(
-          (p) => p.status === "running" || p.status === "terminating",
-        ).length;
-
-        const lines: string[] = [
-          theme.fg(
-            "success",
-            `${processes.length} process(es), ${runningCount} running/terminating`,
-          ),
-        ];
-
-        for (const process of processes) {
-          const status = formatStatusTag(process);
-          lines.push(
-            [
-              `- ${theme.fg("accent", process.name)} ${theme.fg("muted", `(${process.id})`)}`,
-              `  pid: ${process.pid}   status: ${status}`,
-              `  started: ${theme.fg("muted", formatTimestamp(process.startTime))}`,
-              `  ended:   ${theme.fg("muted", formatTimestamp(process.endTime))}`,
-              `  runtime: ${theme.fg("muted", formatRuntime(process.startTime, process.endTime))}`,
-            ].join("\n"),
-          );
-        }
-
-        fields.push(new Text(lines.join("\n"), 0, 0));
-
-        const running = details.processes.filter(
-          (p) => p.status === "running" || p.status === "terminating",
-        );
-        const finishedOk = details.processes.filter(
-          (p) => p.status === "exited" && p.success,
-        ).length;
-        const failed = details.processes.filter(
-          (p) => p.status === "exited" && !p.success,
-        ).length;
-        const killed = details.processes.filter(
-          (p) => p.status === "killed",
-        ).length;
-
-        const runningSummary =
-          running.length > 0
-            ? running
-                .slice(0, 3)
-                .map(
-                  (p) =>
-                    `${theme.fg("accent", `"${p.name}"`)} [${formatStatusTag(p)}]`,
-                )
-                .join(", ")
-            : theme.fg("muted", "no running process");
-
-        const restParts: string[] = [];
-        if (finishedOk > 0) restParts.push(`${finishedOk} finished`);
-        if (failed > 0) restParts.push(`${failed} failed`);
-        if (killed > 0) restParts.push(`${killed} killed`);
-        const restSummary =
-          restParts.length > 0
-            ? theme.fg("muted", ` + ${restParts.join(", ")}`)
-            : "";
-
-        fields.push({
-          label: "Processes",
-          value: runningSummary + restSummary,
-          showCollapsed: true,
-        });
-      } else if (details.action === "logs" && details.logFiles) {
-        fields.push(
-          new Text(
-            [
-              theme.fg("success", "Log files:"),
-              `  stdout: ${theme.fg("accent", details.logFiles.stdoutFile)}`,
-              `  stderr: ${theme.fg("accent", details.logFiles.stderrFile)}`,
-            ].join("\n"),
-            0,
-            0,
-          ),
-        );
-      } else {
-        fields.push({
-          label: "Result",
-          value: details.message,
-          showCollapsed: true,
-        });
       }
 
-      return new ToolBody({ fields }, options, theme);
+      return renderActionResult(result, options, theme);
     },
   });
 }

--- a/src/utils/command-executor.ts
+++ b/src/utils/command-executor.ts
@@ -1,3 +1,6 @@
+// Uses node:child_process directly instead of pi.exec() because process
+// management requires long-lived streaming processes with stdin/stdout piping
+// and detached process groups, which pi.exec() does not support.
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { isAbsolute } from "node:path";

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+import type { Theme } from "@mariozechner/pi-coding-agent";
 import type { ProcessInfo } from "../constants";
 
 export function formatRuntime(
@@ -39,4 +40,35 @@ export function formatStatus(proc: ProcessInfo): string {
 export function truncateCmd(cmd: string, max = 40): string {
   if (cmd.length <= max) return cmd;
   return `${cmd.slice(0, max - 3)}...`;
+}
+
+export function formatTimestamp(ts: number | null): string {
+  if (!ts) return "-";
+  return new Date(ts).toISOString().replace("T", " ").slice(0, 19);
+}
+
+export function formatStatusTag(
+  process: {
+    status: string;
+    success: boolean | null;
+    exitCode: number | null;
+  },
+  theme: Theme,
+): string {
+  switch (process.status) {
+    case "running":
+      return theme.fg("accent", "running");
+    case "terminating":
+      return theme.fg("warning", "terminating");
+    case "terminate_timeout":
+      return theme.fg("error", "terminate_timeout");
+    case "killed":
+      return theme.fg("warning", "killed");
+    case "exited":
+      return process.success
+        ? theme.fg("success", "exit(0)")
+        : theme.fg("error", `exit(${process.exitCode ?? "?"})`);
+    default:
+      return theme.fg("muted", process.status);
+  }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,9 @@
 export { hasAnsi, stripAnsi } from "./ansi";
-export { formatRuntime, formatStatus, truncateCmd } from "./format";
+export {
+  formatRuntime,
+  formatStatus,
+  formatStatusTag,
+  formatTimestamp,
+  truncateCmd,
+} from "./format";
 export { isProcessGroupAlive, killProcessGroup } from "./process-group";


### PR DESCRIPTION
Move renderCall/renderResult logic from the monolithic `src/tools/index.ts` into individual action files under `src/tools/actions/`. Each action file now co-locates its execute function with its render functions.

**Changes:**
- Extract render functions into their respective action files
- Add `renderActionCall` and `renderActionResult` dispatchers in `src/tools/actions/index.ts`
- Slim `src/tools/index.ts` to a thin tool registration file
- Extract shared helpers `formatStatusTag` and `formatTimestamp` to `src/utils/format.ts`
- Align with updated pi-extension guidelines: handle `isPartial`, detect thrown errors via missing details fields, add conditional `ToolFooter` to list renderer, document `child_process` exception

