### PR TITLE
feat: add runtime log watch alerts

### DIFF
--- a/.changeset/log-watch-alerts.md
+++ b/.changeset/log-watch-alerts.md
@@ -1,0 +1,11 @@
+---
+"@aliou/pi-processes": minor
+---
+
+Add runtime log watch alerts for managed processes.
+
+- New `logWatches` option on `process` tool `start` action
+- Watches match log lines on `stdout`, `stderr`, or `both`
+- Default one-time behavior (`repeat: false`), with optional repeat mode
+- On watch match, emit visible UI event and trigger an immediate agent turn
+- Invalid watch config (including bad regex patterns) now fails fast at start time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@ During UI tests that require processes to be running, either give the user a pro
 
 - `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm changeset`
 
+## Debug flags
+
+- `PI_PROCESSES_DEBUG_PREVIEW=1` enables the temporary `process` tool action `debug_preview` for local renderer/UI preview work.
+- Keep this flag off in normal use and user-facing examples.
+
 ## Structure
 
 - `src/index.ts` - entry, `src/manager.ts` - process manager, `src/config.ts` - config loader, `src/constants/` - types/constants, `src/commands/` - slash commands + settings, `src/tools/` - tool/actions, `src/hooks/` - event hooks, `src/components/` - TUI, `src/utils/` - helpers, `src/test/` - test scripts

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -26,10 +26,12 @@ ProcessManager is the only source of events. Everything else reacts to it.
 ```
 ProcessManager.emit()
   │
-  ├─ "process_started"      → fired once when a child process is spawned
-  ├─ "process_ended"        → fired once when a child process exits or is killed
-  └─ "processes_changed"    → fired when the list changes for any other reason
-                              (currently: after clear())
+  ├─ "process_started"        → fired once when a child process is spawned
+  ├─ "process_output_changed" → fired on output changes (throttled)
+  ├─ "process_watch_matched"  → fired when a log watch pattern matches while running
+  ├─ "process_ended"          → fired once when a child process exits or is killed
+  └─ "processes_changed"      → fired when the list changes for any other reason
+                                (currently: after clear())
 ```
 
 Subscribers (registered at boot, never removed):
@@ -51,6 +53,9 @@ LLM calls process(action: "start", name, command, ...)
           → emits "process_started"
               → widget.ts: dockState.autoShow()   [hidden→collapsed if followEnabled]
               → widget.ts: updateWidget()          [re-renders status widget + dock]
+          → while running, output is scanned against optional logWatches
+              → emits "process_watch_matched" for each match
+              → process-watch hook sends visible message + triggerTurn: true
 
 LLM calls process(action: "list")
   → executeList()

--- a/README.md
+++ b/README.md
@@ -114,6 +114,55 @@ Available settings include:
 - Linux: supported
 - Windows: not supported
 
+## Runtime log watch alerts
+
+Use `process` tool `start` with `logWatches` to trigger immediate alerts while the process is still running.
+
+- default behavior: each watch fires once (`repeat: false`)
+- set `repeat: true` to trigger on every match
+- scope by stream (`stdout`, `stderr`, `both`) to reduce noise
+
+Example: server ready marker (one-time default)
+
+```json
+{
+  "action": "start",
+  "name": "dev-server",
+  "command": "pnpm dev",
+  "logWatches": [
+    { "pattern": "ready on http://localhost:3000" }
+  ]
+}
+```
+
+Example: error marker from stderr
+
+```json
+{
+  "action": "start",
+  "name": "builder",
+  "command": "pnpm build --watch",
+  "logWatches": [
+    { "pattern": "TypeError|ReferenceError", "stream": "stderr" }
+  ]
+}
+```
+
+Example: repeatable watch on stdout only
+
+```json
+{
+  "action": "start",
+  "name": "worker",
+  "command": "pnpm worker",
+  "logWatches": [
+    { "pattern": "job completed", "stream": "stdout", "repeat": true }
+  ]
+}
+```
+
+Invalid regex patterns fail fast at process start with a clear error.
+
 ## Troubleshooting
 
 ### Pi started something and I want to see more output

--- a/src/components/processes-component.ts
+++ b/src/components/processes-component.ts
@@ -48,6 +48,19 @@ function truncate(str: string, maxLen: number): string {
   return `${str.slice(0, maxLen - 3)}...`;
 }
 
+function fitCell(
+  value: string,
+  width: number,
+  align: "left" | "right" = "left",
+): string {
+  const truncated = truncateToWidth(value, Math.max(0, width));
+  const pad = Math.max(0, width - visibleWidth(truncated));
+  if (align === "right") {
+    return " ".repeat(pad) + truncated;
+  }
+  return truncated + " ".repeat(pad);
+}
+
 export class ProcessesComponent implements Component {
   private tui: { requestRender: () => void };
   private theme: Theme;
@@ -291,26 +304,24 @@ export class ProcessesComponent implements Component {
         const totalSize = sizes ? sizes.stdout + sizes.stderr : 0;
 
         const statusText = this.formatStatus(proc);
-        const statusPadding =
-          statusWidth + (statusText.length - visibleWidth(statusText));
 
-        // Reserve space for " (proc_N)": 1 space + 1 open paren + id + 1 close paren
-        const maxNameLen = processWidth - proc.id.length - 3;
-        const tName = truncate(proc.name, Math.max(4, maxNameLen));
-        const idSuffix = dim(`(${proc.id})`);
-
+        // Keep process cell bounded even with large IDs.
+        const idPlain = `(${proc.id})`;
+        const maxNameLen = Math.max(
+          1,
+          processWidth - visibleWidth(idPlain) - 1,
+        );
+        const tName = truncate(proc.name, maxNameLen);
         const processCell = isSelected
-          ? `${accent(tName)} ${idSuffix}`
-          : `${tName} ${idSuffix}`;
-        const processCellPadding =
-          processWidth + (processCell.length - visibleWidth(processCell));
+          ? `${accent(tName)} ${dim(` ${idPlain}`)}`
+          : `${tName}${dim(` ${idPlain}`)}`;
 
         const row =
-          processCell.padEnd(processCellPadding) +
-          truncate(proc.command, cmdWidth - 1).padEnd(cmdWidth) +
-          statusText.padEnd(statusPadding) +
-          formatRuntime(proc.startTime, proc.endTime).padEnd(timeWidth) +
-          formatBytes(totalSize).padStart(sizeWidth);
+          fitCell(processCell, processWidth) +
+          fitCell(truncate(proc.command, cmdWidth - 1), cmdWidth) +
+          fitCell(statusText, statusWidth) +
+          fitCell(formatRuntime(proc.startTime, proc.endTime), timeWidth) +
+          fitCell(formatBytes(totalSize), sizeWidth, "right");
 
         if (isSelected) {
           lines.push(padLine(`${accent(">")} ${row}`));

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,9 @@
 export type {
   ExecuteResult,
   KillResult,
+  LogWatch,
+  LogWatchMatchEvent,
+  LogWatchStream,
   ManagerEvent,
   ProcessesDetails,
   ProcessInfo,

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -14,6 +14,14 @@ export const LIVE_STATUSES: ReadonlySet<ProcessStatus> = new Set([
   "terminate_timeout",
 ]);
 
+export type LogWatchStream = "stdout" | "stderr" | "both";
+
+export interface LogWatch {
+  pattern: string;
+  stream?: LogWatchStream;
+  repeat?: boolean;
+}
+
 export interface ProcessInfo {
   id: string;
   name: string;
@@ -32,10 +40,25 @@ export interface ProcessInfo {
   alertOnKill: boolean;
 }
 
+export interface LogWatchMatchEvent {
+  processId: string;
+  processName: string;
+  processCommand: string;
+  source: "stdout" | "stderr";
+  line: string;
+  watch: {
+    index: number;
+    pattern: string;
+    stream: LogWatchStream;
+    repeat: boolean;
+  };
+}
+
 export type ManagerEvent =
   | { type: "process_started"; info: ProcessInfo }
   | { type: "process_ended"; info: ProcessInfo }
   | { type: "process_output_changed"; id: string }
+  | { type: "process_watch_matched"; match: LogWatchMatchEvent }
   | { type: "processes_changed" };
 
 export type KillResult =
@@ -53,6 +76,7 @@ export interface StartOptions {
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: LogWatch[];
 }
 
 export interface ProcessesDetails {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ import { setupBackgroundBlocker } from "./background-blocker";
 import { setupCleanupHook } from "./cleanup";
 import { setupMessageRenderer } from "./message-renderer";
 import { setupProcessEndHook } from "./process-end";
+import { setupProcessWatchHook } from "./process-watch";
 import { type DockActions, setupProcessWidget } from "./widget";
 
 export type { DockActions };
@@ -16,6 +17,7 @@ export function setupProcessesHooks(
 ): { update: () => void; dockActions: DockActions } {
   setupCleanupHook(pi, manager);
   setupProcessEndHook(pi, manager);
+  setupProcessWatchHook(pi, manager);
 
   if (config.interception.blockBackgroundCommands) {
     setupBackgroundBlocker(pi);

--- a/src/hooks/message-renderer.ts
+++ b/src/hooks/message-renderer.ts
@@ -6,7 +6,8 @@ import type {
 import { Text } from "@mariozechner/pi-tui";
 import { MESSAGE_TYPE_PROCESS_UPDATE } from "../constants";
 
-interface ProcessUpdateDetails {
+interface ProcessLifecycleDetails {
+  kind?: "lifecycle";
   processId: string;
   processName: string;
   command: string;
@@ -16,10 +17,25 @@ interface ProcessUpdateDetails {
   runtime: string;
 }
 
+interface ProcessWatchMatchDetails {
+  kind: "watch_matched";
+  processId: string;
+  processName: string;
+  command: string;
+  source: "stdout" | "stderr";
+  line: string;
+  watch: {
+    index: number;
+    pattern: string;
+    stream: "stdout" | "stderr" | "both";
+    repeat: boolean;
+  };
+}
+
 interface ProcessUpdateMessage {
   customType: string;
   content: string | Array<{ type: string; text?: string }>;
-  details?: ProcessUpdateDetails;
+  details?: ProcessLifecycleDetails | ProcessWatchMatchDetails;
 }
 
 function getContentText(
@@ -35,7 +51,9 @@ function getContentText(
 }
 
 export function setupMessageRenderer(pi: ExtensionAPI) {
-  pi.registerMessageRenderer<ProcessUpdateDetails>(
+  pi.registerMessageRenderer<
+    ProcessLifecycleDetails | ProcessWatchMatchDetails
+  >(
     MESSAGE_TYPE_PROCESS_UPDATE,
     (
       message: ProcessUpdateMessage,
@@ -46,6 +64,20 @@ export function setupMessageRenderer(pi: ExtensionAPI) {
 
       if (!details) {
         return new Text(getContentText(message.content), 0, 0);
+      }
+
+      if (details.kind === "watch_matched") {
+        const streamColor = details.source === "stderr" ? "warning" : "accent";
+        const text =
+          theme.fg("success", "* ") +
+          theme.fg("accent", `"${details.processName}"`) +
+          theme.fg("muted", ` (${details.processId}) `) +
+          theme.fg("success", "watch matched ") +
+          theme.fg("muted", `/${details.watch.pattern}/ `) +
+          theme.fg(streamColor, `[${details.source}]`) +
+          theme.fg("muted", ` ${details.line}`);
+
+        return new Text(text, 0, 0);
       }
 
       let icon: string;

--- a/src/hooks/process-end.ts
+++ b/src/hooks/process-end.ts
@@ -4,6 +4,7 @@ import type { ProcessManager } from "../manager";
 import { formatRuntime } from "../utils";
 
 interface ProcessUpdateDetails {
+  kind: "lifecycle";
   processId: string;
   processName: string;
   command: string;
@@ -43,6 +44,7 @@ export function setupProcessEndHook(pi: ExtensionAPI, manager: ProcessManager) {
     // Send the message to the conversation - displayed via custom renderer in UI
     // Only trigger an agent turn when the notification preferences say so.
     const details: ProcessUpdateDetails = {
+      kind: "lifecycle",
       processId: info.id,
       processName: info.name,
       command: info.command,

--- a/src/hooks/process-watch.ts
+++ b/src/hooks/process-watch.ts
@@ -1,0 +1,83 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { MESSAGE_TYPE_PROCESS_UPDATE } from "../constants";
+import type { ProcessManager } from "../manager";
+
+interface ProcessWatchUpdateDetails {
+  kind: "watch_matched";
+  processId: string;
+  processName: string;
+  command: string;
+  source: "stdout" | "stderr";
+  line: string;
+  watch: {
+    index: number;
+    pattern: string;
+    stream: "stdout" | "stderr" | "both";
+    repeat: boolean;
+  };
+}
+
+const REPEAT_WATCH_TURN_COOLDOWN_MS = 5000;
+
+export function setupProcessWatchHook(
+  pi: ExtensionAPI,
+  manager: ProcessManager,
+) {
+  const lastRepeatTurnAt = new Map<string, number>();
+
+  manager.onEvent((event) => {
+    if (event.type === "process_ended") {
+      // Cleanup cooldown state for this process.
+      const prefix = `${event.info.id}:`;
+      for (const key of lastRepeatTurnAt.keys()) {
+        if (key.startsWith(prefix)) {
+          lastRepeatTurnAt.delete(key);
+        }
+      }
+      return;
+    }
+
+    if (event.type !== "process_watch_matched") return;
+
+    const match = event.match;
+    const message =
+      `Watch matched for '${match.processName}' (${match.processId}) ` +
+      `[${match.source}] /${match.watch.pattern}/`;
+
+    const details: ProcessWatchUpdateDetails = {
+      kind: "watch_matched",
+      processId: match.processId,
+      processName: match.processName,
+      command: match.processCommand,
+      source: match.source,
+      line: match.line,
+      watch: {
+        index: match.watch.index,
+        pattern: match.watch.pattern,
+        stream: match.watch.stream,
+        repeat: match.watch.repeat,
+      },
+    };
+
+    let triggerTurn = true;
+    if (match.watch.repeat) {
+      const watchKey = `${match.processId}:${match.watch.index}`;
+      const now = Date.now();
+      const last = lastRepeatTurnAt.get(watchKey) ?? 0;
+      triggerTurn = now - last >= REPEAT_WATCH_TURN_COOLDOWN_MS;
+      if (triggerTurn) {
+        lastRepeatTurnAt.set(watchKey, now);
+      }
+    }
+
+    pi.sendMessage(
+      {
+        customType: MESSAGE_TYPE_PROCESS_UPDATE,
+        content: message,
+        display: true,
+        details,
+      },
+      { triggerTurn },
+    );
+  });
+}

--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -195,3 +195,137 @@ describe("process_output_changed", () => {
     expect(ids.has(info2.id)).toBe(true);
   });
 });
+
+describe("process_watch_matched", () => {
+  let manager: ProcessManager;
+
+  afterEach(() => {
+    manager.cleanup();
+  });
+
+  it("fires once by default on first matching line", async () => {
+    manager = new ProcessManager();
+    const events = collectEvents(manager);
+
+    const info = manager.start(
+      "watch-once",
+      "bash -c 'echo ready; echo ready; echo ready'",
+      "/tmp",
+      {
+        logWatches: [{ pattern: "ready" }],
+      },
+    );
+
+    await waitForEnd(manager, info.id);
+
+    const matches = events.filter((e) => e.type === "process_watch_matched");
+    expect(matches).toHaveLength(1);
+
+    const first = matches[0];
+    if (first.type === "process_watch_matched") {
+      expect(first.match.processId).toBe(info.id);
+      expect(first.match.source).toBe("stdout");
+      expect(first.match.watch.repeat).toBe(false);
+      expect(first.match.line).toBe("ready");
+    }
+  });
+
+  it("supports repeat watches", async () => {
+    manager = new ProcessManager();
+    const events = collectEvents(manager);
+
+    const info = manager.start(
+      "watch-repeat",
+      "bash -c 'echo done; echo done; echo done'",
+      "/tmp",
+      {
+        logWatches: [{ pattern: "done", repeat: true }],
+      },
+    );
+
+    await waitForEnd(manager, info.id);
+
+    const matches = events.filter((e) => e.type === "process_watch_matched");
+    expect(matches).toHaveLength(3);
+  });
+
+  it("respects stream scoping", async () => {
+    manager = new ProcessManager();
+    const events = collectEvents(manager);
+
+    const info = manager.start(
+      "watch-stream",
+      "bash -c 'echo out; echo err >&2'",
+      "/tmp",
+      {
+        logWatches: [{ pattern: "err", stream: "stderr" }],
+      },
+    );
+
+    await waitForEnd(manager, info.id);
+
+    const matches = events.filter((e) => e.type === "process_watch_matched");
+    expect(matches).toHaveLength(1);
+
+    const match = matches[0];
+    if (match.type === "process_watch_matched") {
+      expect(match.match.source).toBe("stderr");
+      expect(match.match.line).toBe("err");
+    }
+  });
+
+  it("stream both matches stdout and stderr", async () => {
+    manager = new ProcessManager();
+    const events = collectEvents(manager);
+
+    const info = manager.start(
+      "watch-both",
+      "bash -c 'echo marker; echo marker >&2'",
+      "/tmp",
+      {
+        logWatches: [{ pattern: "marker", stream: "both", repeat: true }],
+      },
+    );
+
+    await waitForEnd(manager, info.id);
+
+    const matches = events.filter((e) => e.type === "process_watch_matched");
+    expect(matches).toHaveLength(2);
+
+    const sources = new Set(
+      matches
+        .filter(
+          (e): e is Extract<ManagerEvent, { type: "process_watch_matched" }> =>
+            e.type === "process_watch_matched",
+        )
+        .map((e) => e.match.source),
+    );
+
+    expect(sources.has("stdout")).toBe(true);
+    expect(sources.has("stderr")).toBe(true);
+  });
+
+  it("matches trailing partial line at process end", async () => {
+    manager = new ProcessManager();
+    const events = collectEvents(manager);
+
+    const info = manager.start("watch-trailing", "printf ready", "/tmp", {
+      logWatches: [{ pattern: "ready" }],
+    });
+
+    await waitForEnd(manager, info.id);
+
+    const matches = events.filter((e) => e.type === "process_watch_matched");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("throws for invalid watch regex", () => {
+    manager = new ProcessManager();
+
+    expect(() =>
+      manager.start("bad-watch", "echo ok", "/tmp", {
+        logWatches: [{ pattern: "(" }],
+      }),
+    ).toThrowError(/Invalid log watch pattern/);
+  });
+});

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -14,6 +14,8 @@ import type { Writable } from "node:stream";
 import {
   type KillResult,
   LIVE_STATUSES,
+  type LogWatch,
+  type LogWatchStream,
   type ManagerEvent,
   type ProcessInfo,
   type ProcessStatus,
@@ -23,12 +25,24 @@ import {
 import { isProcessGroupAlive, killProcessGroup } from "./utils";
 import { spawnCommand } from "./utils/command-executor";
 
+interface ResolvedWatch {
+  index: number;
+  pattern: string;
+  regex: RegExp;
+  stream: LogWatchStream;
+  repeat: boolean;
+  fired: boolean;
+}
+
 interface ManagedProcess extends ProcessInfo {
   process: ChildProcess;
   stdin: Writable | null;
   stdinClosed: boolean;
   lastSignalSent: NodeJS.Signals | null;
   combinedFile: string;
+  stdoutPendingLine: string;
+  stderrPendingLine: string;
+  watches: ResolvedWatch[];
 }
 
 interface ProcessManagerOptions {
@@ -153,6 +167,7 @@ export class ProcessManager {
       }
 
       this.flushPendingOutputChanged(managed.id);
+      this.flushPendingLines(managed);
 
       if (managed.lastSignalSent) {
         managed.success = false;
@@ -172,6 +187,7 @@ export class ProcessManager {
     cwd: string,
     options?: StartOptions,
   ): ProcessInfo {
+    const resolvedWatches = this.resolveLogWatches(options?.logWatches);
     const id = `proc_${++this.counter}`;
     const stdoutFile = join(this.logDir, `${id}-stdout.log`);
     const stderrFile = join(this.logDir, `${id}-stderr.log`);
@@ -206,6 +222,9 @@ export class ProcessManager {
       stdin: child.stdin,
       stdinClosed: false,
       lastSignalSent: null,
+      stdoutPendingLine: "",
+      stderrPendingLine: "",
+      watches: resolvedWatches,
     };
 
     this.processes.set(id, managed);
@@ -226,15 +245,10 @@ export class ProcessManager {
     child.stdout?.on("data", (data: Buffer) => {
       try {
         appendFileSync(stdoutFile, data);
-        const lines = data.toString().split("\n");
-        // The last element after split is either empty (if data ended with \n)
-        // or a partial line. We write all parts with the prefix and newline.
-        const tagged = lines
-          .map((line, i) =>
-            i < lines.length - 1 ? `1:${line}\n` : line ? `1:${line}\n` : "",
-          )
-          .join("");
+        const lines = this.extractCompleteLines(managed, "stdout", data);
+        const tagged = lines.map((line) => `1:${line}\n`).join("");
         if (tagged) appendFileSync(combinedFile, tagged);
+        this.matchWatches(managed, "stdout", lines);
         this.notifyOutputChanged(id);
       } catch {
         // Ignore
@@ -244,13 +258,10 @@ export class ProcessManager {
     child.stderr?.on("data", (data: Buffer) => {
       try {
         appendFileSync(stderrFile, data);
-        const lines = data.toString().split("\n");
-        const tagged = lines
-          .map((line, i) =>
-            i < lines.length - 1 ? `2:${line}\n` : line ? `2:${line}\n` : "",
-          )
-          .join("");
+        const lines = this.extractCompleteLines(managed, "stderr", data);
+        const tagged = lines.map((line) => `2:${line}\n`).join("");
         if (tagged) appendFileSync(combinedFile, tagged);
+        this.matchWatches(managed, "stderr", lines);
         this.notifyOutputChanged(id);
       } catch {
         // Ignore
@@ -265,6 +276,7 @@ export class ProcessManager {
       managed.success = code === 0;
 
       this.flushPendingOutputChanged(id);
+      this.flushPendingLines(managed);
 
       if (signal) {
         this.transition(managed, "killed");
@@ -285,6 +297,7 @@ export class ProcessManager {
         managed.success = false;
         managed.endTime = Date.now();
         this.flushPendingOutputChanged(id);
+        this.flushPendingLines(managed);
         this.transition(managed, "exited");
       }
     });
@@ -442,6 +455,7 @@ export class ProcessManager {
     }
 
     this.flushPendingOutputChanged(id);
+    this.flushPendingLines(managed);
     this.transition(managed, "killed");
     return { ok: true, info: this.toProcessInfo(managed) };
   }
@@ -572,6 +586,132 @@ export class ProcessManager {
       };
     } catch {
       return { stdout: 0, stderr: 0 };
+    }
+  }
+
+  private resolveLogWatches(input?: LogWatch[]): ResolvedWatch[] {
+    if (!input || input.length === 0) return [];
+
+    return input.map((watch, index) => {
+      const pattern = watch.pattern?.trim();
+      if (!pattern) {
+        throw new Error(`logWatches[${index}].pattern is required`);
+      }
+
+      let regex: RegExp;
+      try {
+        regex = new RegExp(pattern);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "invalid regular expression";
+        throw new Error(
+          `Invalid log watch pattern at logWatches[${index}]: ${message}`,
+        );
+      }
+
+      const stream = watch.stream ?? "both";
+      if (stream !== "stdout" && stream !== "stderr" && stream !== "both") {
+        throw new Error(
+          `Invalid logWatches[${index}].stream: ${stream}. Expected stdout, stderr, or both`,
+        );
+      }
+
+      return {
+        index,
+        pattern,
+        regex,
+        stream,
+        repeat: watch.repeat ?? false,
+        fired: false,
+      };
+    });
+  }
+
+  private extractCompleteLines(
+    managed: ManagedProcess,
+    source: "stdout" | "stderr",
+    data: Buffer,
+  ): string[] {
+    const chunk = data.toString();
+    const pending =
+      source === "stdout"
+        ? managed.stdoutPendingLine
+        : managed.stderrPendingLine;
+    const merged = pending + chunk;
+    const parts = merged.split(/\r?\n/);
+    const completeLines = parts.slice(0, -1);
+    const nextPending = parts[parts.length - 1] ?? "";
+
+    if (source === "stdout") {
+      managed.stdoutPendingLine = nextPending;
+    } else {
+      managed.stderrPendingLine = nextPending;
+    }
+
+    return completeLines;
+  }
+
+  private flushPendingLines(managed: ManagedProcess): void {
+    if (managed.stdoutPendingLine) {
+      try {
+        appendFileSync(
+          managed.combinedFile,
+          `1:${managed.stdoutPendingLine}\n`,
+        );
+      } catch {
+        // Ignore
+      }
+      this.matchWatches(managed, "stdout", [managed.stdoutPendingLine]);
+      managed.stdoutPendingLine = "";
+    }
+
+    if (managed.stderrPendingLine) {
+      try {
+        appendFileSync(
+          managed.combinedFile,
+          `2:${managed.stderrPendingLine}\n`,
+        );
+      } catch {
+        // Ignore
+      }
+      this.matchWatches(managed, "stderr", [managed.stderrPendingLine]);
+      managed.stderrPendingLine = "";
+    }
+  }
+
+  private matchWatches(
+    managed: ManagedProcess,
+    source: "stdout" | "stderr",
+    lines: string[],
+  ): void {
+    if (managed.watches.length === 0 || lines.length === 0) return;
+
+    for (const line of lines) {
+      for (const watch of managed.watches) {
+        if (!watch.repeat && watch.fired) continue;
+        if (watch.stream !== "both" && watch.stream !== source) continue;
+
+        if (!watch.regex.test(line)) continue;
+
+        watch.fired = true;
+
+        this.emit({
+          type: "process_watch_matched",
+          match: {
+            processId: managed.id,
+            processName: managed.name,
+            processCommand: managed.command,
+            source,
+            line,
+            watch: {
+              index: watch.index,
+              pattern: watch.pattern,
+              stream: watch.stream,
+              repeat: watch.repeat,
+            },
+          },
+        });
+      }
     }
   }
 

--- a/src/tools/actions/debug.ts
+++ b/src/tools/actions/debug.ts
@@ -35,7 +35,12 @@ export function executeDebugPreview(params: DebugParams): ExecuteResult {
 
   if (preview === "start") {
     const process = mockProcess();
-    const message = `Started "${process.name}" (${process.id}, PID: ${process.pid})\nLogs: ${process.stdoutFile}`;
+    const message = [
+      `Started "${process.name}" (${process.id}, PID: ${process.pid})`,
+      "Log files:",
+      `  stdout: ${process.stdoutFile}`,
+      `  stderr: ${process.stderrFile}`,
+    ].join("\n");
     return {
       content: [{ type: "text", text: message }],
       details: {
@@ -100,6 +105,10 @@ export function executeDebugPreview(params: DebugParams): ExecuteResult {
             "error: simulated stack trace line",
           ],
         },
+        logFiles: {
+          stdoutFile: "/tmp/pi-processes-demo/proc_42-stdout.log",
+          stderrFile: "/tmp/pi-processes-demo/proc_42-stderr.log",
+        },
       },
     };
   }
@@ -119,12 +128,5 @@ export function executeDebugPreview(params: DebugParams): ExecuteResult {
     };
   }
 
-  return {
-    content: [{ type: "text", text: "Debug preview: forced error" }],
-    details: {
-      action: "start",
-      success: false,
-      message: "Invalid logWatches[0].pattern: Unterminated group",
-    },
-  };
+  throw new Error("Invalid logWatches[0].pattern: Unterminated group");
 }

--- a/src/tools/actions/debug.ts
+++ b/src/tools/actions/debug.ts
@@ -1,0 +1,130 @@
+import type { ExecuteResult, ProcessInfo } from "../../constants";
+
+interface DebugParams {
+  preview?: "start" | "list" | "output" | "logs" | "error";
+}
+
+function mockProcess(overrides?: Partial<ProcessInfo>): ProcessInfo {
+  const now = Date.now();
+  return {
+    id: "proc_42",
+    name: "demo-server",
+    pid: 4242,
+    command: "pnpm dev --port 3000",
+    cwd: "/tmp/demo",
+    startTime: now - 12_000,
+    endTime: null,
+    status: "running",
+    exitCode: null,
+    success: null,
+    stdoutFile: "/tmp/pi-processes-demo/proc_42-stdout.log",
+    stderrFile: "/tmp/pi-processes-demo/proc_42-stderr.log",
+    alertOnSuccess: false,
+    alertOnFailure: true,
+    alertOnKill: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Temporary no-side-effect previews for process tool renderers.
+ * Remove before release.
+ */
+export function executeDebugPreview(params: DebugParams): ExecuteResult {
+  const preview = params.preview ?? "start";
+
+  if (preview === "start") {
+    const process = mockProcess();
+    const message = `Started "${process.name}" (${process.id}, PID: ${process.pid})\nLogs: ${process.stdoutFile}`;
+    return {
+      content: [{ type: "text", text: message }],
+      details: {
+        action: "start",
+        success: true,
+        message,
+        process,
+      },
+    };
+  }
+
+  if (preview === "list") {
+    const processes = [
+      mockProcess(),
+      mockProcess({
+        id: "proc_11",
+        name: "builder",
+        pid: 1011,
+        command: "pnpm build --watch",
+      }),
+      mockProcess({
+        id: "proc_10",
+        name: "tests",
+        pid: 1010,
+        command: "pnpm test",
+        status: "exited",
+        success: false,
+        endTime: Date.now() - 3_000,
+        exitCode: 1,
+      }),
+    ];
+
+    return {
+      content: [{ type: "text", text: "Debug preview: list" }],
+      details: {
+        action: "list",
+        success: true,
+        message: "Debug preview: list",
+        processes,
+      },
+    };
+  }
+
+  if (preview === "output") {
+    return {
+      content: [{ type: "text", text: "Debug preview: output" }],
+      details: {
+        action: "output",
+        success: true,
+        message:
+          '"demo-server" (proc_42) [running]: 4 stdout lines, 2 stderr lines',
+        output: {
+          status: "running",
+          stdout: [
+            "starting...",
+            "loading config",
+            "ready on http://localhost:3000",
+            "watching for changes",
+          ],
+          stderr: [
+            "warn: deprecated option in config",
+            "error: simulated stack trace line",
+          ],
+        },
+      },
+    };
+  }
+
+  if (preview === "logs") {
+    return {
+      content: [{ type: "text", text: "Debug preview: logs" }],
+      details: {
+        action: "logs",
+        success: true,
+        message: "Debug preview: logs",
+        logFiles: {
+          stdoutFile: "/tmp/pi-processes-demo/proc_42-stdout.log",
+          stderrFile: "/tmp/pi-processes-demo/proc_42-stderr.log",
+        },
+      },
+    };
+  }
+
+  return {
+    content: [{ type: "text", text: "Debug preview: forced error" }],
+    details: {
+      action: "start",
+      success: false,
+      message: "Invalid logWatches[0].pattern: Unterminated group",
+    },
+  };
+}

--- a/src/tools/actions/index.ts
+++ b/src/tools/actions/index.ts
@@ -10,6 +10,8 @@ import { executeOutput } from "./output";
 import { executeStart } from "./start";
 import { executeWrite } from "./write";
 
+const DEBUG_PREVIEW_ENABLED = process.env.PI_PROCESSES_DEBUG_PREVIEW === "1";
+
 interface ActionParams {
   action: string;
   command?: string;
@@ -49,6 +51,11 @@ export async function executeAction(
     case "write":
       return executeWrite(params, manager);
     case "debug_preview":
+      if (!DEBUG_PREVIEW_ENABLED) {
+        throw new Error(
+          "Action 'debug_preview' is disabled. Set PI_PROCESSES_DEBUG_PREVIEW=1 to enable.",
+        );
+      }
       return executeDebugPreview(params);
     default:
       return {

--- a/src/tools/actions/index.ts
+++ b/src/tools/actions/index.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ExecuteResult } from "../../constants";
 import type { ProcessManager } from "../../manager";
 import { executeClear } from "./clear";
+import { executeDebugPreview } from "./debug";
 import { executeKill } from "./kill";
 import { executeList } from "./list";
 import { executeLogs } from "./logs";
@@ -19,6 +20,12 @@ interface ActionParams {
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: Array<{
+    pattern: string;
+    stream?: "stdout" | "stderr" | "both";
+    repeat?: boolean;
+  }>;
+  preview?: "start" | "list" | "output" | "logs" | "error";
 }
 
 export async function executeAction(
@@ -41,6 +48,8 @@ export async function executeAction(
       return executeClear(manager);
     case "write":
       return executeWrite(params, manager);
+    case "debug_preview":
+      return executeDebugPreview(params);
     default:
       return {
         content: [{ type: "text", text: `Unknown action: ${params.action}` }],

--- a/src/tools/actions/output.ts
+++ b/src/tools/actions/output.ts
@@ -79,6 +79,12 @@ export function executeOutput(
       success: true,
       message,
       output,
+      logFiles: logFiles
+        ? {
+            stdoutFile: logFiles.stdoutFile,
+            stderrFile: logFiles.stderrFile,
+          }
+        : undefined,
     },
   };
 }

--- a/src/tools/actions/start.ts
+++ b/src/tools/actions/start.ts
@@ -2,12 +2,21 @@ import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { ExecuteResult } from "../../constants";
 import type { ProcessManager } from "../../manager";
 
+type WatchStream = "stdout" | "stderr" | "both";
+
+interface StartLogWatch {
+  pattern: string;
+  stream?: WatchStream;
+  repeat?: boolean;
+}
+
 interface StartParams {
   name?: string;
   command?: string;
   alertOnSuccess?: boolean;
   alertOnFailure?: boolean;
   alertOnKill?: boolean;
+  logWatches?: StartLogWatch[];
 }
 
 export function executeStart(
@@ -36,11 +45,40 @@ export function executeStart(
     };
   }
 
-  const proc = manager.start(params.name, params.command, ctx.cwd, {
-    alertOnSuccess: params.alertOnSuccess,
-    alertOnFailure: params.alertOnFailure,
-    alertOnKill: params.alertOnKill,
-  });
+  const watchValidationError = validateLogWatches(params.logWatches);
+  if (watchValidationError) {
+    return {
+      content: [{ type: "text", text: watchValidationError }],
+      details: {
+        action: "start",
+        success: false,
+        message: watchValidationError,
+      },
+    };
+  }
+
+  let proc: ReturnType<ProcessManager["start"]>;
+  try {
+    proc = manager.start(params.name, params.command, ctx.cwd, {
+      alertOnSuccess: params.alertOnSuccess,
+      alertOnFailure: params.alertOnFailure,
+      alertOnKill: params.alertOnKill,
+      logWatches: params.logWatches,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Invalid start options: ${error.message}`
+        : "Invalid start options";
+    return {
+      content: [{ type: "text", text: message }],
+      details: {
+        action: "start",
+        success: false,
+        message,
+      },
+    };
+  }
 
   const message = `Started "${proc.name}" (${proc.id}, PID: ${proc.pid})\nLogs: ${proc.stdoutFile}`;
   return {
@@ -52,4 +90,49 @@ export function executeStart(
       process: proc,
     },
   };
+}
+
+function validateLogWatches(watches?: StartLogWatch[]): string | null {
+  if (!watches) return null;
+
+  if (!Array.isArray(watches)) {
+    return "Invalid parameter: logWatches must be an array";
+  }
+
+  for (const [index, watch] of watches.entries()) {
+    if (!watch || typeof watch !== "object") {
+      return `Invalid logWatches[${index}]: expected an object`;
+    }
+
+    if (
+      typeof watch.pattern !== "string" ||
+      watch.pattern.trim().length === 0
+    ) {
+      return `Invalid logWatches[${index}].pattern: expected non-empty string`;
+    }
+
+    try {
+      // Validate regex syntax at process start for fast feedback.
+      new RegExp(watch.pattern);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "invalid regular expression";
+      return `Invalid logWatches[${index}].pattern: ${message}`;
+    }
+
+    if (
+      watch.stream !== undefined &&
+      watch.stream !== "stdout" &&
+      watch.stream !== "stderr" &&
+      watch.stream !== "both"
+    ) {
+      return `Invalid logWatches[${index}].stream: expected stdout, stderr, or both`;
+    }
+
+    if (watch.repeat !== undefined && typeof watch.repeat !== "boolean") {
+      return `Invalid logWatches[${index}].repeat: expected boolean`;
+    }
+  }
+
+  return null;
 }

--- a/src/tools/actions/start.ts
+++ b/src/tools/actions/start.ts
@@ -80,7 +80,12 @@ export function executeStart(
     };
   }
 
-  const message = `Started "${proc.name}" (${proc.id}, PID: ${proc.pid})\nLogs: ${proc.stdoutFile}`;
+  const message = [
+    `Started "${proc.name}" (${proc.id}, PID: ${proc.pid})`,
+    "Log files:",
+    `  stdout: ${proc.stdoutFile}`,
+    `  stderr: ${proc.stderrFile}`,
+  ].join("\n");
   return {
     content: [{ type: "text", text: message }],
     details: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
-import { ToolBody, ToolCallHeader, ToolFooter } from "@aliou/pi-utils-ui";
+import { ToolBody, ToolCallHeader } from "@aliou/pi-utils-ui";
 import { StringEnum } from "@mariozechner/pi-ai";
 import type {
   AgentToolResult,
@@ -10,26 +10,28 @@ import { Text } from "@mariozechner/pi-tui";
 import { type Static, Type } from "@sinclair/typebox";
 import type { ProcessesDetails } from "../constants";
 import type { ProcessManager } from "../manager";
-import { formatRuntime, hasAnsi, stripAnsi, truncateCmd } from "../utils";
+import { formatRuntime, hasAnsi, stripAnsi } from "../utils";
 import { executeAction } from "./actions";
 
+const DEBUG_PREVIEW_ENABLED = process.env.PI_PROCESSES_DEBUG_PREVIEW === "1";
+
+const PROCESS_ACTIONS = [
+  "start",
+  "list",
+  "output",
+  "logs",
+  "kill",
+  "clear",
+  "write",
+  ...(DEBUG_PREVIEW_ENABLED ? (["debug_preview"] as const) : []),
+] as const;
+
 const ProcessesParams = Type.Object({
-  action: StringEnum(
-    [
-      "start",
-      "list",
-      "output",
-      "logs",
-      "kill",
-      "clear",
-      "write",
-      "debug_preview",
-    ] as const,
-    {
-      description:
-        "Action: start (run command), list (show all), output (get recent output), logs (get log file paths), kill (terminate), clear (remove finished), write (write to stdin), debug_preview (temporary UI preview, no side effects)",
-    },
-  ),
+  action: StringEnum(PROCESS_ACTIONS, {
+    description: DEBUG_PREVIEW_ENABLED
+      ? "Action: start (run command), list (show all), output (get recent output), logs (get log file paths), kill (terminate), clear (remove finished), write (write to stdin), debug_preview (temporary UI preview, no side effects)"
+      : "Action: start (run command), list (show all), output (get recent output), logs (get log file paths), kill (terminate), clear (remove finished), write (write to stdin)",
+  }),
   command: Type.Optional(
     Type.String({ description: "Command to run (required for start)" }),
   ),
@@ -74,12 +76,16 @@ const ProcessesParams = Type.Object({
         "Get a turn to react when process is killed by external signal (default: false). Note: killing via tool never triggers a turn.",
     }),
   ),
-  preview: Type.Optional(
-    StringEnum(["start", "list", "output", "logs", "error"] as const, {
-      description:
-        "For action=debug_preview only: which rendered result variant to preview (default: start)",
-    }),
-  ),
+  ...(DEBUG_PREVIEW_ENABLED
+    ? {
+        preview: Type.Optional(
+          StringEnum(["start", "list", "output", "logs", "error"] as const, {
+            description:
+              "For action=debug_preview only: which rendered result variant to preview (default: start)",
+          }),
+        ),
+      }
+    : {}),
   logWatches: Type.Optional(
     Type.Array(
       Type.Object(
@@ -128,9 +134,11 @@ export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
 - kill: Terminate a process (requires 'id')
 - clear: Remove all finished processes from the list
 - write: Write to process stdin (requires 'id' and 'input', optional 'end' to close stdin)
-- debug_preview: Temporary renderer preview for process tool UIs (no process side effects)
-  - preview: start | list | output | logs | error (default: start)
-
+${
+  DEBUG_PREVIEW_ENABLED
+    ? "- debug_preview: Temporary renderer preview for process tool UIs (no process side effects)\n  - preview: start | list | output | logs | error (default: start)\n"
+    : ""
+}
 Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work - you'll be informed if something requires attention.
 
 Note: User always sees process updates in the UI. The notify flags control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`,
@@ -218,17 +226,49 @@ Note: User always sees process updates in the UI. The notify flags control wheth
       const { details } = result;
 
       if (!details) {
-        const text = result.content[0];
-        return new Text(
-          text?.type === "text" && text.text ? text.text : "No result",
-          0,
-          0,
-        );
+        const message = result.content
+          .map((part) =>
+            part.type === "text" && "text" in part && part.text
+              ? part.text
+              : "",
+          )
+          .join("\n")
+          .trim();
+
+        return new Text(message || "Tool execution failed", 0, 0);
       }
 
       const fields: Array<
         { label: string; value: string; showCollapsed?: boolean } | Text
       > = [];
+
+      const formatTimestamp = (ts: number | null): string => {
+        if (!ts) return "-";
+        return new Date(ts).toISOString().replace("T", " ").slice(0, 19);
+      };
+
+      const formatStatusTag = (process: {
+        status: string;
+        success: boolean | null;
+        exitCode: number | null;
+      }): string => {
+        switch (process.status) {
+          case "running":
+            return theme.fg("accent", "running");
+          case "terminating":
+            return theme.fg("warning", "terminating");
+          case "terminate_timeout":
+            return theme.fg("error", "terminate_timeout");
+          case "killed":
+            return theme.fg("warning", "killed");
+          case "exited":
+            return process.success
+              ? theme.fg("success", "exit(0)")
+              : theme.fg("error", `exit(${process.exitCode ?? "?"})`);
+          default:
+            return theme.fg("muted", process.status);
+        }
+      };
 
       if (!details.success) {
         fields.push({
@@ -238,6 +278,24 @@ Note: User always sees process updates in the UI. The notify flags control wheth
         });
       } else if (details.action === "start" && details.process) {
         const process = details.process;
+
+        fields.push(
+          new Text(
+            [
+              theme.fg("success", "Started process"),
+              `  name: ${theme.fg("accent", process.name)}`,
+              `  command: ${process.command}`,
+              `  id: ${theme.fg("accent", process.id)}`,
+              `  pid: ${String(process.pid)}`,
+              "  Log files:",
+              `    - stdout: ${theme.fg("accent", process.stdoutFile)}`,
+              `    - stderr: ${theme.fg("accent", process.stderrFile)}`,
+            ].join("\n"),
+            0,
+            0,
+          ),
+        );
+
         fields.push({
           label: "Status",
           value:
@@ -281,6 +339,15 @@ Note: User always sees process updates in the UI. The notify flags control wheth
           }
         }
 
+        if (details.logFiles) {
+          lines.push(
+            "",
+            theme.fg("success", "Log files:"),
+            `  stdout: ${theme.fg("accent", details.logFiles.stdoutFile)}`,
+            `  stderr: ${theme.fg("accent", details.logFiles.stderrFile)}`,
+          );
+        }
+
         if (hadAnsi) {
           lines.push(
             "",
@@ -311,63 +378,92 @@ Note: User always sees process updates in the UI. The notify flags control wheth
         details.processes &&
         details.processes.length > 0
       ) {
+        const processes = [...details.processes];
+        const statusRank = (status: string): number => {
+          switch (status) {
+            case "running":
+              return 0;
+            case "terminating":
+              return 1;
+            case "terminate_timeout":
+              return 2;
+            case "killed":
+              return 3;
+            case "exited":
+              return 4;
+            default:
+              return 5;
+          }
+        };
+
+        processes.sort((a, b) => {
+          const rankDiff = statusRank(a.status) - statusRank(b.status);
+          if (rankDiff !== 0) return rankDiff;
+          return b.startTime - a.startTime;
+        });
+
+        const runningCount = processes.filter(
+          (p) => p.status === "running" || p.status === "terminating",
+        ).length;
+
         const lines: string[] = [
-          theme.fg("success", `${details.processes.length} process(es):`),
+          theme.fg(
+            "success",
+            `${processes.length} process(es), ${runningCount} running/terminating`,
+          ),
         ];
 
-        for (const process of details.processes) {
-          let status: string;
-          switch (process.status) {
-            case "running":
-              status = theme.fg("accent", "running");
-              break;
-            case "terminating":
-              status = theme.fg("warning", "terminating");
-              break;
-            case "terminate_timeout":
-              status = theme.fg("error", "terminate_timeout");
-              break;
-            case "killed":
-              status = theme.fg("warning", "killed");
-              break;
-            case "exited":
-              status = process.success
-                ? theme.fg("success", "exit(0)")
-                : theme.fg("error", `exit(${process.exitCode ?? "?"})`);
-              break;
-            default:
-              status = theme.fg("muted", process.status);
-          }
-
+        for (const process of processes) {
+          const status = formatStatusTag(process);
           lines.push(
-            `  ${theme.fg("accent", `"${process.name}"`)} ${theme.fg("muted", `(${process.id})`)}: ${truncateCmd(process.command)} [${status}] ${formatRuntime(process.startTime, process.endTime)}`,
+            [
+              `- ${theme.fg("accent", process.name)} ${theme.fg("muted", `(${process.id})`)}`,
+              `  pid: ${process.pid}   status: ${status}`,
+              `  started: ${theme.fg("muted", formatTimestamp(process.startTime))}`,
+              `  ended:   ${theme.fg("muted", formatTimestamp(process.endTime))}`,
+              `  runtime: ${theme.fg("muted", formatRuntime(process.startTime, process.endTime))}`,
+            ].join("\n"),
           );
         }
 
         fields.push(new Text(lines.join("\n"), 0, 0));
 
-        // Collapsed summary: first 3 processes
-        const summary = details.processes
-          .slice(0, 3)
-          .map((p) => {
-            const s =
-              p.status === "running"
-                ? theme.fg("accent", "running")
-                : p.status === "exited" && p.success
-                  ? theme.fg("success", "exit(0)")
-                  : p.status === "exited"
-                    ? theme.fg("error", `exit(${p.exitCode ?? "?"})`)
-                    : theme.fg("muted", p.status);
-            return `${theme.fg("accent", `"${p.name}"`)} [${s}]`;
-          })
-          .join(", ");
-        const more =
-          details.processes.length > 3
-            ? theme.fg("muted", ` +${details.processes.length - 3} more`)
+        const running = details.processes.filter(
+          (p) => p.status === "running" || p.status === "terminating",
+        );
+        const finishedOk = details.processes.filter(
+          (p) => p.status === "exited" && p.success,
+        ).length;
+        const failed = details.processes.filter(
+          (p) => p.status === "exited" && !p.success,
+        ).length;
+        const killed = details.processes.filter(
+          (p) => p.status === "killed",
+        ).length;
+
+        const runningSummary =
+          running.length > 0
+            ? running
+                .slice(0, 3)
+                .map(
+                  (p) =>
+                    `${theme.fg("accent", `"${p.name}"`)} [${formatStatusTag(p)}]`,
+                )
+                .join(", ")
+            : theme.fg("muted", "no running process");
+
+        const restParts: string[] = [];
+        if (finishedOk > 0) restParts.push(`${finishedOk} finished`);
+        if (failed > 0) restParts.push(`${failed} failed`);
+        if (killed > 0) restParts.push(`${killed} killed`);
+        const restSummary =
+          restParts.length > 0
+            ? theme.fg("muted", ` + ${restParts.join(", ")}`)
             : "";
+
         fields.push({
           label: "Processes",
-          value: summary + more,
+          value: runningSummary + restSummary,
           showCollapsed: true,
         });
       } else if (details.action === "logs" && details.logFiles) {
@@ -390,24 +486,7 @@ Note: User always sees process updates in the UI. The notify flags control wheth
         });
       }
 
-      const footerItems: Array<{
-        label: string;
-        value: string;
-        tone: "accent" | "success" | "error" | "warning" | "muted";
-      }> = [];
-      if (!details.success) {
-        footerItems.push({
-          label: "status",
-          value: "error",
-          tone: "error",
-        });
-      }
-      const footer =
-        footerItems.length > 0
-          ? new ToolFooter(theme, { items: footerItems })
-          : undefined;
-
-      return new ToolBody({ fields, footer }, options, theme);
+      return new ToolBody({ fields }, options, theme);
     },
   });
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,10 +15,19 @@ import { executeAction } from "./actions";
 
 const ProcessesParams = Type.Object({
   action: StringEnum(
-    ["start", "list", "output", "logs", "kill", "clear", "write"] as const,
+    [
+      "start",
+      "list",
+      "output",
+      "logs",
+      "kill",
+      "clear",
+      "write",
+      "debug_preview",
+    ] as const,
     {
       description:
-        "Action: start (run command), list (show all), output (get recent output), logs (get log file paths), kill (terminate), clear (remove finished), write (write to stdin)",
+        "Action: start (run command), list (show all), output (get recent output), logs (get log file paths), kill (terminate), clear (remove finished), write (write to stdin), debug_preview (temporary UI preview, no side effects)",
     },
   ),
   command: Type.Optional(
@@ -65,6 +74,37 @@ const ProcessesParams = Type.Object({
         "Get a turn to react when process is killed by external signal (default: false). Note: killing via tool never triggers a turn.",
     }),
   ),
+  preview: Type.Optional(
+    StringEnum(["start", "list", "output", "logs", "error"] as const, {
+      description:
+        "For action=debug_preview only: which rendered result variant to preview (default: start)",
+    }),
+  ),
+  logWatches: Type.Optional(
+    Type.Array(
+      Type.Object(
+        {
+          pattern: Type.String({
+            description:
+              "Regular expression pattern to match against process output lines",
+          }),
+          stream: Type.Optional(
+            StringEnum(["stdout", "stderr", "both"] as const, {
+              description:
+                "Which stream to watch (default: both). Use stdout/stderr to reduce noise.",
+            }),
+          ),
+          repeat: Type.Optional(
+            Type.Boolean({
+              description:
+                "Trigger every time this pattern matches (default: false, one-time)",
+            }),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  ),
 });
 
 type ProcessesParamsType = Static<typeof ProcessesParams>;
@@ -78,12 +118,18 @@ export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
   - alertOnSuccess (default: false): Get a turn to react when process completes successfully
   - alertOnFailure (default: true): Get a turn to react when process crashes/fails
   - alertOnKill (default: false): Get a turn to react if killed by external signal (killing via tool never triggers a turn)
+  - logWatches (optional): Runtime output watches that trigger immediate alerts while running
+    - pattern: regex string to match per output line
+    - stream: stdout | stderr | both (default both)
+    - repeat: false by default (single-fire). Set true for repeat alerts
 - list: Show all managed processes with their IDs and names
 - output: Get recent stdout/stderr (requires 'id')
 - logs: Get log file paths to inspect with read tool (requires 'id')
 - kill: Terminate a process (requires 'id')
 - clear: Remove all finished processes from the list
 - write: Write to process stdin (requires 'id' and 'input', optional 'end' to close stdin)
+- debug_preview: Temporary renderer preview for process tool UIs (no process side effects)
+  - preview: start | list | output | logs | error (default: start)
 
 Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work - you'll be informed if something requires attention.
 
@@ -122,6 +168,13 @@ Note: User always sees process updates in the UI. The notify flags control wheth
             longArgs.push({ label: "command", value: args.command });
           }
         }
+
+        if (args.logWatches && args.logWatches.length > 0) {
+          optionArgs.push({
+            label: "watches",
+            value: String(args.logWatches.length),
+          });
+        }
       }
 
       if (
@@ -132,6 +185,10 @@ Note: User always sees process updates in the UI. The notify flags control wheth
         args.id
       ) {
         mainArg = args.id;
+      }
+
+      if (args.action === "debug_preview" && args.preview) {
+        mainArg = args.preview;
       }
 
       if (args.action === "write" && args.input) {


### PR DESCRIPTION
## Summary
- add runtime `logWatches` support on process start (pattern, stream scope, repeat)
- emit watch match events while process is running and trigger immediate agent turn
- add fail-fast validation for watch config/patterns
- improve process tool rendering (start/list/output) and harmonize "Log files" wording
- add temporary `debug_preview` action for renderer previews, gated by `PI_PROCESSES_DEBUG_PREVIEW=1`
- add tests for watch behavior, including `stream: both`

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
