### PR TITLE
refactor: use strict ID-only resolution for process actions

### DIFF
--- a/.changeset/strict-id-resolution.md
+++ b/.changeset/strict-id-resolution.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-processes": minor
+---
+
+Process lookup now uses exact ID matching only. Fuzzy name/command matching via `find()` has been removed. The `id` parameter in tool actions accepts only the process ID returned by `start` and `list`. The `/ps` list UI merges the ID and Name columns into a single "Process" column showing `name (id)`.

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -273,7 +273,7 @@ Search mode (bottom line replaced):
 | `list` | See all processes and their statuses |
 | `output` | Read recent stdout/stderr from memory (fast, limited) |
 | `logs` | Get file paths to read full logs with the `read` tool |
-| `kill` | Terminate a process by id or name |
+| `kill` | Terminate a process by id |
 | `clear` | Remove all finished processes |
 | `write` | Send input to a running process's stdin |
 

--- a/src/commands/kill/command.ts
+++ b/src/commands/kill/command.ts
@@ -19,7 +19,7 @@ export function registerPsKillCommand(
       let processId: string | undefined;
 
       if (arg) {
-        const proc = manager.find(arg);
+        const proc = manager.get(arg);
         if (!proc) {
           return;
         }
@@ -49,18 +49,18 @@ export function registerPsKillCommand(
         }
       }
 
+      if (!processId) return;
+
       const proc = manager.get(processId);
-      if (!proc) {
-        return;
-      }
+      if (!proc) return;
 
       const signal =
         proc.status === "terminate_timeout" ? "SIGKILL" : "SIGTERM";
       const timeoutMs = signal === "SIGKILL" ? 200 : 3000;
-      const result = await manager.kill(processId, { signal, timeoutMs });
+      const result = await manager.kill(proc.id, { signal, timeoutMs });
 
       if (result.ok) {
-        if (dockActions.getFocusedProcessId() === processId) {
+        if (dockActions.getFocusedProcessId() === proc.id) {
           dockActions.setFocus(null);
         }
       }

--- a/src/commands/logs/command.ts
+++ b/src/commands/logs/command.ts
@@ -18,7 +18,7 @@ export function registerPsLogsCommand(
       let processId: string | undefined;
 
       if (arg) {
-        const proc = manager.find(arg);
+        const proc = manager.get(arg);
         if (!proc) return;
         processId = proc.id;
       }

--- a/src/commands/pin/command.ts
+++ b/src/commands/pin/command.ts
@@ -17,7 +17,7 @@ export function registerPsPinCommand(
       let processId: string | undefined;
 
       if (arg) {
-        const proc = manager.find(arg);
+        const proc = manager.get(arg);
         if (!proc) {
           return;
         }
@@ -27,6 +27,7 @@ export function registerPsPinCommand(
         if (!processId) return;
       }
 
+      if (!processId) return;
       dockActions.setFocus(processId);
     },
   });

--- a/src/components/processes-component.ts
+++ b/src/components/processes-component.ts
@@ -243,8 +243,7 @@ export class ProcessesComponent implements Component {
       const scaleFactor =
         innerWidth < minTotalWidth ? innerWidth / minTotalWidth : 1;
 
-      const idWidth = Math.max(6, Math.floor(9 * scaleFactor));
-      const nameWidth = Math.max(8, Math.floor(15 * scaleFactor));
+      const processWidth = Math.max(14, Math.floor(24 * scaleFactor));
       const statusWidth = Math.max(10, Math.floor(18 * scaleFactor));
       const timeWidth = Math.max(4, Math.floor(8 * scaleFactor));
       const sizeWidth = Math.max(4, Math.floor(8 * scaleFactor));
@@ -258,8 +257,7 @@ export class ProcessesComponent implements Component {
       // Calculate command column width based on remaining space
       const fixedWidth =
         prefixWidth +
-        idWidth +
-        nameWidth +
+        processWidth +
         statusWidth +
         timeWidth +
         sizeWidth +
@@ -269,8 +267,7 @@ export class ProcessesComponent implements Component {
       lines.push(padLine(""));
       const header =
         "  " +
-        dim("ID".padEnd(idWidth)) +
-        dim("Name".padEnd(nameWidth)) +
+        dim("Process".padEnd(processWidth)) +
         dim("Command".padEnd(cmdWidth)) +
         dim("Status".padEnd(statusWidth)) +
         dim("Time".padEnd(timeWidth)) +
@@ -297,11 +294,19 @@ export class ProcessesComponent implements Component {
         const statusPadding =
           statusWidth + (statusText.length - visibleWidth(statusText));
 
+        // Reserve space for " (proc_N)": 1 space + 1 open paren + id + 1 close paren
+        const maxNameLen = processWidth - proc.id.length - 3;
+        const tName = truncate(proc.name, Math.max(4, maxNameLen));
+        const idSuffix = dim(`(${proc.id})`);
+
+        const processCell = isSelected
+          ? `${accent(tName)} ${idSuffix}`
+          : `${tName} ${idSuffix}`;
+        const processCellPadding =
+          processWidth + (processCell.length - visibleWidth(processCell));
+
         const row =
-          (isSelected
-            ? accent(proc.id.padEnd(idWidth))
-            : proc.id.padEnd(idWidth)) +
-          truncate(proc.name, nameWidth - 1).padEnd(nameWidth) +
+          processCell.padEnd(processCellPadding) +
           truncate(proc.command, cmdWidth - 1).padEnd(cmdWidth) +
           statusText.padEnd(statusPadding) +
           formatRuntime(proc.startTime, proc.endTime).padEnd(timeWidth) +

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -254,22 +254,6 @@ export class ProcessManager {
     return managed ? this.toProcessInfo(managed) : null;
   }
 
-  find(query: string): ProcessInfo | null {
-    const byId = this.processes.get(query);
-    if (byId) return this.toProcessInfo(byId);
-
-    const queryLower = query.toLowerCase();
-    for (const managed of this.processes.values()) {
-      if (managed.name.toLowerCase().includes(queryLower)) {
-        return this.toProcessInfo(managed);
-      }
-      if (managed.command.toLowerCase().includes(queryLower)) {
-        return this.toProcessInfo(managed);
-      }
-    }
-    return null;
-  }
-
   getOutput(
     id: string,
     tailLines = 100,

--- a/src/tools/actions/kill.ts
+++ b/src/tools/actions/kill.ts
@@ -20,7 +20,7 @@ export async function executeKill(
     };
   }
 
-  const proc = manager.find(params.id);
+  const proc = manager.get(params.id);
   if (!proc) {
     const message = `Process not found: ${params.id}`;
     return {

--- a/src/tools/actions/logs.ts
+++ b/src/tools/actions/logs.ts
@@ -20,7 +20,7 @@ export function executeLogs(
     };
   }
 
-  const proc = manager.find(params.id);
+  const proc = manager.get(params.id);
   if (!proc) {
     const message = `Process not found: ${params.id}`;
     return {
@@ -35,7 +35,7 @@ export function executeLogs(
 
   const logFiles = manager.getLogFiles(proc.id);
   if (!logFiles) {
-    const message = `Could not get log files for: ${proc.id}`;
+    const message = `Could not get log files for "${proc.name}" (${proc.id})`;
     return {
       content: [{ type: "text", text: message }],
       details: {

--- a/src/tools/actions/output.ts
+++ b/src/tools/actions/output.ts
@@ -24,7 +24,7 @@ export function executeOutput(
     };
   }
 
-  const proc = manager.find(params.id);
+  const proc = manager.get(params.id);
   if (!proc) {
     const message = `Process not found: ${params.id}`;
     return {
@@ -40,7 +40,7 @@ export function executeOutput(
   const { defaultTailLines } = configLoader.getConfig().output;
   const output = manager.getOutput(proc.id, defaultTailLines);
   if (!output) {
-    const message = `Could not read output for: ${proc.id}`;
+    const message = `Could not read output for "${proc.name}" (${proc.id})`;
     return {
       content: [{ type: "text", text: message }],
       details: {

--- a/src/tools/actions/write.ts
+++ b/src/tools/actions/write.ts
@@ -35,7 +35,7 @@ export function executeWrite(
     };
   }
 
-  const process = manager.find(id);
+  const process = manager.get(id);
   if (!process) {
     return {
       content: [{ type: "text", text: `Process not found: ${id}` }],
@@ -75,7 +75,7 @@ export function executeWrite(
     content: [
       {
         type: "text",
-        text: `Wrote ${input.length} bytes to ${process.id}${suffix}`,
+        text: `Wrote ${input.length} bytes to "${process.name}" (${process.id})${suffix}`,
       },
     ],
     details: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,7 +33,7 @@ const ProcessesParams = Type.Object({
   id: Type.Optional(
     Type.String({
       description:
-        "Process ID or name to match (required for output/kill/logs/write). Can be proc_N or friendly name.",
+        "Process ID, returned by start and list actions (required for output/kill/logs/write)",
     }),
   ),
   input: Type.Optional(
@@ -79,9 +79,9 @@ export function setupProcessesTools(pi: ExtensionAPI, manager: ProcessManager) {
   - alertOnFailure (default: true): Get a turn to react when process crashes/fails
   - alertOnKill (default: false): Get a turn to react if killed by external signal (killing via tool never triggers a turn)
 - list: Show all managed processes with their IDs and names
-- output: Get recent stdout/stderr (requires 'id' - can be proc_N or name match)
+- output: Get recent stdout/stderr (requires 'id')
 - logs: Get log file paths to inspect with read tool (requires 'id')
-- kill: Terminate a process (requires 'id' - can be proc_N or name match like "backend")
+- kill: Terminate a process (requires 'id')
 - clear: Remove all finished processes from the list
 - write: Write to process stdin (requires 'id' and 'input', optional 'end' to close stdin)
 
@@ -283,7 +283,7 @@ Note: User always sees process updates in the UI. The notify flags control wheth
           }
 
           lines.push(
-            `  ${process.id} ${theme.fg("accent", `"${process.name}"`)}: ${truncateCmd(process.command)} [${status}] ${formatRuntime(process.startTime, process.endTime)}`,
+            `  ${theme.fg("accent", `"${process.name}"`)} ${theme.fg("muted", `(${process.id})`)}: ${truncateCmd(process.command)} [${status}] ${formatRuntime(process.startTime, process.endTime)}`,
           );
         }
 


### PR DESCRIPTION
Remove ProcessManager.find() (fuzzy name/command matching). All callers
now use get() for exact ID lookup.

- Update tool schema: id param describes exact ID, no name match language
- Update all action files and slash commands to use get()
- Merge ID+Name into single Process column in /ps list UI
- Flip tool result list render to "name" (id) order
- Include process name in write action success message
- Update EVENTS.md to reflect id-only kill