### PR TITLE
fix: prevent crash on /new with running background processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
     "typebox": "^1.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "0.69.0",
-    "@mariozechner/pi-tui": "0.69.0"
+    "@mariozechner/pi-coding-agent": "0.72.1",
+    "@mariozechner/pi-tui": "0.72.1"
   },
   "devDependencies": {
     "@aliou/biome-plugins": "^0.3.2",
     "@biomejs/biome": "^2.3.13",
     "@changesets/cli": "^2.27.11",
-    "@mariozechner/pi-ai": "0.69.0",
-    "@mariozechner/pi-coding-agent": "0.69.0",
+    "@mariozechner/pi-ai": "0.72.1",
+    "@mariozechner/pi-coding-agent": "0.72.1",
     "@types/node": "^25.0.10",
     "husky": "^9.1.7",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mariozechner/pi-ai': 0.69.0
-  '@mariozechner/pi-tui': 0.69.0
+  '@mariozechner/pi-ai': 0.72.1
+  '@mariozechner/pi-tui': 0.72.1
 
 importers:
 
@@ -14,16 +14,16 @@ importers:
     dependencies:
       '@aliou/pi-utils-settings':
         specifier: ^0.10.0
-        version: 0.10.0(@mariozechner/pi-coding-agent@0.69.0(ws@8.19.0)(zod@3.25.76))
+        version: 0.10.0(@mariozechner/pi-coding-agent@0.72.1(ws@8.19.0)(zod@3.25.76))
       '@aliou/pi-utils-ui':
         specifier: ^0.1.0
-        version: 0.1.0(@mariozechner/pi-coding-agent@0.69.0(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.69.0)
+        version: 0.1.0(@mariozechner/pi-coding-agent@0.72.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.72.1)
       '@aliou/sh':
         specifier: ^0.1.0
         version: 0.1.0
       '@mariozechner/pi-tui':
-        specifier: 0.69.0
-        version: 0.69.0
+        specifier: 0.72.1
+        version: 0.72.1
       typebox:
         specifier: ^1.0.0
         version: 1.1.31
@@ -38,11 +38,11 @@ importers:
         specifier: ^2.27.11
         version: 2.29.8(@types/node@25.2.3)
       '@mariozechner/pi-ai':
-        specifier: 0.69.0
-        version: 0.69.0(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.72.1
+        version: 0.72.1(ws@8.19.0)(zod@3.25.76)
       '@mariozechner/pi-coding-agent':
-        specifier: 0.69.0
-        version: 0.69.0(ws@8.19.0)(zod@3.25.76)
+        specifier: 0.72.1
+        version: 0.72.1(ws@8.19.0)(zod@3.25.76)
       '@types/node':
         specifier: ^25.0.10
         version: 25.2.3
@@ -75,14 +75,14 @@ packages:
     resolution: {integrity: sha512-GAgA29J7fnswE+eFp+ktkQomRUB7YsZVdJ1vqWcllWYVfMDbSZ9orDTgf0Rr6wnrZ7s/SBeipGlxEBLDEch+qA==}
     peerDependencies:
       '@mariozechner/pi-coding-agent': '>=0.51.0'
-      '@mariozechner/pi-tui': 0.69.0
+      '@mariozechner/pi-tui': 0.72.1
 
   '@aliou/sh@0.1.0':
     resolution: {integrity: sha512-MtVSUqNAHK8a0yQdwv4ADlTIBnEg8bpFXcqp0PaxwqxhSWAxcIrpAIPbsc3CJnUK3R++BcgaxBZ5saicHtU+8Q==}
     engines: {node: '>=22'}
 
-  '@anthropic-ai/sdk@0.90.0':
-    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -596,30 +596,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.2':
-    resolution: {integrity: sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==}
+  '@mariozechner/clipboard@0.3.5':
+    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
     engines: {node: '>= 10'}
 
   '@mariozechner/jiti@2.6.5':
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.69.0':
-    resolution: {integrity: sha512-dYZjee7QEIwVVbDGCGriiLjDT34IdMlXMjMp4drVKcLEuVc+BztyODwu3w4ZORVvwaySGGlF9UALjJKUVoXiug==}
+  '@mariozechner/pi-agent-core@0.72.1':
+    resolution: {integrity: sha512-Z5XH9mUDsBymh7Prtk5Eun4Cs+s9C3uzynug+oWAjzQESjjnCuy7KU6Ek8E9Eg+b9yroCwVw2ItLDxp2E3vYjA==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.69.0':
-    resolution: {integrity: sha512-bl838sr57zx/apkiTeNPFQgbBkGXN4HHhm2oghzSRohJIBrR+H001bTeco7Osuke+EZTxO3V5Aev2qlZdUa2xw==}
+  '@mariozechner/pi-ai@0.72.1':
+    resolution: {integrity: sha512-mOq71Pjnu72xxzwrh52VIiNwt+/a+Wpa11k5segi01/zTZJt8eMDc5Q2z6GhczYMr5+6EpZ8T+BaeHqq0jk5ag==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.69.0':
-    resolution: {integrity: sha512-/EFn43RO2TtMgZI4fMXNepIvbWm2GqhhaLIHBkrO7tRbRCzgvDYkw9sMLKhdf1Ihom2CjC3T/fzQRIPasRSIrQ==}
+  '@mariozechner/pi-coding-agent@0.72.1':
+    resolution: {integrity: sha512-gKApiLfAYpvPnWThvwXrLjZIhsziSSUKBph7DHCy/1IomuIGN1MTxS/9ZtcuFqPy3/+VfEUOKegGlY6m+CRNlA==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.69.0':
-    resolution: {integrity: sha512-/82SOMzCA1srivwfcSO8r9XLdAgJNcgpWzNZY33IqqvGev8Q4iWY/hA1wAkLB0l7PKJJ4Dh57xS4IGHbyVM7lA==}
+  '@mariozechner/pi-tui@0.72.1':
+    resolution: {integrity: sha512-KjeqzMQp4vafomfkvI8HKv5/52PqRP5BmlowGC8WKyOaB+u0UkkTdfM5U1Ui3ty2gA7FOfglVRiyvcitiWwvMQ==}
     engines: {node: '>=20.0.0'}
 
   '@mistralai/mistralai@2.2.1':
@@ -1930,8 +1930,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vite@7.3.1:
@@ -2083,18 +2083,18 @@ snapshots:
     dependencies:
       '@biomejs/biome': 2.4.2
 
-  '@aliou/pi-utils-settings@0.10.0(@mariozechner/pi-coding-agent@0.69.0(ws@8.19.0)(zod@3.25.76))':
+  '@aliou/pi-utils-settings@0.10.0(@mariozechner/pi-coding-agent@0.72.1(ws@8.19.0)(zod@3.25.76))':
     optionalDependencies:
-      '@mariozechner/pi-coding-agent': 0.69.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-coding-agent': 0.72.1(ws@8.19.0)(zod@3.25.76)
 
-  '@aliou/pi-utils-ui@0.1.0(@mariozechner/pi-coding-agent@0.69.0(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.69.0)':
+  '@aliou/pi-utils-ui@0.1.0(@mariozechner/pi-coding-agent@0.72.1(ws@8.19.0)(zod@3.25.76))(@mariozechner/pi-tui@0.72.1)':
     dependencies:
-      '@mariozechner/pi-coding-agent': 0.69.0(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.69.0
+      '@mariozechner/pi-coding-agent': 0.72.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui': 0.72.1
 
   '@aliou/sh@0.1.0': {}
 
-  '@anthropic-ai/sdk@0.90.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.91.1(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -2844,7 +2844,7 @@ snapshots:
   '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@mariozechner/clipboard@0.3.2':
+  '@mariozechner/clipboard@0.3.5':
     optionalDependencies:
       '@mariozechner/clipboard-darwin-arm64': 0.3.2
       '@mariozechner/clipboard-darwin-universal': 0.3.2
@@ -2863,9 +2863,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.69.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-agent-core@0.72.1(ws@8.19.0)(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.69.0(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.72.1(ws@8.19.0)(zod@3.25.76)
       typebox: 1.1.31
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -2876,9 +2876,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.69.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-ai@0.72.1(ws@8.19.0)(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1035.0
       '@google/genai': 1.41.0
       '@mistralai/mistralai': 2.2.1
@@ -2898,12 +2898,12 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.69.0(ws@8.19.0)(zod@3.25.76)':
+  '@mariozechner/pi-coding-agent@0.72.1(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.69.0(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.69.0(ws@8.19.0)(zod@3.25.76)
-      '@mariozechner/pi-tui': 0.69.0
+      '@mariozechner/pi-agent-core': 0.72.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.72.1(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-tui': 0.72.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -2919,10 +2919,10 @@ snapshots:
       strip-ansi: 7.1.2
       typebox: 1.1.31
       undici: 7.22.0
-      uuid: 11.1.0
+      uuid: 14.0.0
       yaml: 2.8.2
     optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
+      '@mariozechner/clipboard': 0.3.5
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -2932,7 +2932,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.69.0':
+  '@mariozechner/pi-tui@0.72.1':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2
@@ -4312,7 +4312,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   vite@7.3.1(@types/node@25.2.3)(yaml@2.8.2):
     dependencies:

--- a/src/hooks/process-end.ts
+++ b/src/hooks/process-end.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { MESSAGE_TYPE_PROCESS_UPDATE, type ProcessInfo } from "../constants";
 import type { ProcessManager } from "../manager";
 import { formatRuntime } from "../utils";
+import { safeSendMessage } from "./utils";
 
 interface ProcessUpdateDetails {
   kind: "lifecycle";
@@ -54,7 +55,8 @@ export function setupProcessEndHook(pi: ExtensionAPI, manager: ProcessManager) {
       runtime,
     };
 
-    pi.sendMessage(
+    safeSendMessage(
+      pi,
       {
         customType: MESSAGE_TYPE_PROCESS_UPDATE,
         content: message,

--- a/src/hooks/process-watch.ts
+++ b/src/hooks/process-watch.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { MESSAGE_TYPE_PROCESS_UPDATE } from "../constants";
 import type { ProcessManager } from "../manager";
+import { safeSendMessage } from "./utils";
 
 interface ProcessWatchUpdateDetails {
   kind: "watch_matched";
@@ -70,7 +71,8 @@ export function setupProcessWatchHook(
       }
     }
 
-    pi.sendMessage(
+    safeSendMessage(
+      pi,
       {
         customType: MESSAGE_TYPE_PROCESS_UPDATE,
         content: message,

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,23 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Send a message via pi, swallowing stale-context errors.
+ *
+ * After /new, /resume, or /fork, the pi proxy is invalidated and all
+ * method calls throw. This wrapper catches that specific error so the
+ * extension doesn't crash — the event is simply lost for the old session.
+ */
+export function safeSendMessage(
+  pi: ExtensionAPI,
+  message: Parameters<ExtensionAPI["sendMessage"]>[0],
+  options?: Parameters<ExtensionAPI["sendMessage"]>[1],
+): void {
+  try {
+    pi.sendMessage(message, options);
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes("stale")) {
+      return;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
Bandaid fix for #35.

## Problem

Running `/new` while background processes are active crashes pi:

```
Error: This extension ctx state is stale after session replacement or reload.
    at Object.sendMessage (loader.js:20:41)
    at EventEmitter.<anonymous> (process-end.ts:57:8)
```

`session_shutdown` kills all processes, their exit handlers fire `pi.sendMessage()` on the now-stale `pi` proxy, which throws.

## Fix

`safeSendMessage()` wraps `pi.sendMessage()` — catches stale-context errors instead of crashing. Processes are still killed on session shutdown as before. The fix just prevents the crash during teardown.

## Tradeoff

Process events that fire after the pi proxy is invalidated are silently dropped. This is acceptable for a bandaid — a full reattach solution will come with the extension rewrite.