### PR TITLE
fix: Prevent TUI rendering errors by stripping control chars

### DIFF
--- a/src/components/log-dock-component.ts
+++ b/src/components/log-dock-component.ts
@@ -15,6 +15,7 @@ import type { Component } from "@mariozechner/pi-tui";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { LIVE_STATUSES } from "../constants";
 import type { ProcessManager } from "../manager";
+import { stripAnsi } from "../utils";
 import { LogFileViewer } from "./log-file-viewer";
 
 const PROCESS_COLORS: ThemeColor[] = [
@@ -153,7 +154,7 @@ export class LogDockComponent implements Component {
       const lastLogs = this.manager.getCombinedOutput(running[0].id, 1);
       if (lastLogs && lastLogs.length > 0) {
         const lastLog = truncateToWidth(
-          lastLogs[lastLogs.length - 1].text,
+          stripAnsi(lastLogs[lastLogs.length - 1].text),
           innerWidth,
         );
         lines.push(padLine(dim(lastLog)));

--- a/src/utils/ansi.test.ts
+++ b/src/utils/ansi.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi } from "./ansi";
+
+describe("stripAnsi", () => {
+  it("strips CSI styling sequences", () => {
+    expect(stripAnsi("\u001b[31mred\u001b[0m")).toBe("red");
+  });
+
+  it("strips generic OSC sequences", () => {
+    expect(stripAnsi("\u001b]0;title\u0007hello")).toBe("hello");
+  });
+
+  it("strips carriage returns and other control chars that can corrupt TUI rendering", () => {
+    const output = stripAnsi("step 1\rstep 2\b\b done");
+    expect(output).toBe("step 1step 2 done");
+    for (const char of output) {
+      const code = char.codePointAt(0) ?? 0;
+      const isDisallowedC0 =
+        (code >= 0x00 && code <= 0x08) ||
+        (code >= 0x0b && code <= 0x1f) ||
+        code === 0x7f;
+      expect(isDisallowedC0).toBe(false);
+    }
+  });
+});

--- a/src/utils/ansi.test.ts
+++ b/src/utils/ansi.test.ts
@@ -11,15 +11,12 @@ describe("stripAnsi", () => {
   });
 
   it("strips carriage returns and other control chars that can corrupt TUI rendering", () => {
-    const output = stripAnsi("step 1\rstep 2\b\b done");
-    expect(output).toBe("step 1step 2 done");
-    for (const char of output) {
-      const code = char.codePointAt(0) ?? 0;
-      const isDisallowedC0 =
-        (code >= 0x00 && code <= 0x08) ||
-        (code >= 0x0b && code <= 0x1f) ||
-        code === 0x7f;
-      expect(isDisallowedC0).toBe(false);
-    }
+    expect(stripAnsi("step 1\rstep 2\b\b done")).toBe("step 1step 2 done");
+    expect(stripAnsi("null\u0000byte")).toBe("nullbyte");
+    expect(stripAnsi("delete\u007fchar")).toBe("deletechar");
+  });
+
+  it("preserves tabs and newlines", () => {
+    expect(stripAnsi("one\ttwo\nthree")).toBe("one\ttwo\nthree");
   });
 });

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -1,10 +1,11 @@
 /**
- * Strip ANSI escape codes from a string.
+ * Strip ANSI escape codes and other terminal control characters from a string.
  *
  * Removes:
  * - All CSI sequences (\x1b[...X) - SGR, cursor movement, erase, scroll, etc.
- * - OSC 8 hyperlinks (\x1b]8;;URL\x07)
+ * - OSC sequences (\x1b]...\x07 or \x1b]...\x1b\\)
  * - APC sequences (\x1b_...\x07 or \x1b_...\x1b\\)
+ * - Remaining C0 control chars except tab/newline
  */
 /**
  * Check if a string contains ANSI escape codes.
@@ -18,19 +19,33 @@ export function stripAnsi(str: string): string {
   const ESC = String.fromCodePoint(0x001b);
   const BEL = String.fromCodePoint(0x0007);
 
-  if (!str.includes(ESC)) {
-    return str;
+  let clean = str;
+
+  if (str.includes(ESC)) {
+    // Strip all CSI sequences (ESC[...X where X is any letter)
+    clean = clean.replace(new RegExp(`${ESC}\\[[0-9;]*[A-Za-z]`, "gu"), "");
+    // Strip OSC sequences: ESC]...<BEL> or ESC]...<ESC>\\
+    clean = clean.replace(
+      new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
+      "",
+    );
+    // Strip APC sequences: ESC_...<BEL> or ESC_...<ESC>\\ (used for cursor marker)
+    clean = clean.replace(
+      new RegExp(`${ESC}_[^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
+      "",
+    );
   }
 
-  // Strip all CSI sequences (ESC[...X where X is any letter)
-  let clean = str.replace(new RegExp(`${ESC}\\[[0-9;]*[A-Za-z]`, "gu"), "");
-  // Strip OSC 8 hyperlinks: ESC]8;;URL<BEL> and ESC]8;;<BEL>
-  clean = clean.replace(new RegExp(`${ESC}\\]8;;[^${BEL}]*${BEL}`, "gu"), "");
-  // Strip APC sequences: ESC_...<BEL> or ESC_...<ESC>\\ (used for cursor marker)
-  clean = clean.replace(
-    new RegExp(`${ESC}_[^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
-    "",
-  );
-
-  return clean;
+  // Strip terminal control chars like carriage return/backspace that can
+  // corrupt TUI layout when rendered back into pi.
+  return Array.from(clean)
+    .filter((char) => {
+      const code = char.codePointAt(0) ?? 0;
+      const isDisallowedC0 =
+        (code >= 0x00 && code <= 0x08) ||
+        (code >= 0x0b && code <= 0x1f) ||
+        code === 0x7f;
+      return !isDisallowedC0;
+    })
+    .join("");
 }

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -7,45 +7,39 @@
  * - APC sequences (\x1b_...\x07 or \x1b_...\x1b\\)
  * - Remaining C0 control chars except tab/newline
  */
+const ESC = String.fromCodePoint(0x001b);
+const BEL = String.fromCodePoint(0x0007);
+
+const ANSI_REPLACEMENTS: RegExp[] = [
+  // CSI sequences: SGR, cursor movement, erase, scroll, etc.
+  new RegExp(`${ESC}\\[[0-9;]*[A-Za-z]`, "gu"),
+  // OSC sequences: ESC]...<BEL> or ESC]...<ESC>\\.
+  new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
+  // APC sequences: ESC_...<BEL> or ESC_...<ESC>\\.
+  new RegExp(`${ESC}_[^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
+];
+
+// Strip C0 terminal control characters that can corrupt TUI layout when
+// rendered back into pi, such as carriage return and backspace. Keep tabs and
+// newlines because logs use them as printable whitespace/line breaks.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: this regex intentionally targets terminal control characters.
+const TERMINAL_CONTROL_CHARS = /[\u0000-\u0008\u000b-\u001f\u007f]/gu;
+
 /**
  * Check if a string contains ANSI escape codes.
  */
 export function hasAnsi(str: string): boolean {
-  return str.includes(String.fromCodePoint(0x001b));
+  return str.includes(ESC);
 }
 
 export function stripAnsi(str: string): string {
-  // ESC = \u001b, BEL = \u0007
-  const ESC = String.fromCodePoint(0x001b);
-  const BEL = String.fromCodePoint(0x0007);
-
   let clean = str;
 
   if (str.includes(ESC)) {
-    // Strip all CSI sequences (ESC[...X where X is any letter)
-    clean = clean.replace(new RegExp(`${ESC}\\[[0-9;]*[A-Za-z]`, "gu"), "");
-    // Strip OSC sequences: ESC]...<BEL> or ESC]...<ESC>\\
-    clean = clean.replace(
-      new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
-      "",
-    );
-    // Strip APC sequences: ESC_...<BEL> or ESC_...<ESC>\\ (used for cursor marker)
-    clean = clean.replace(
-      new RegExp(`${ESC}_[^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "gu"),
-      "",
-    );
+    for (const pattern of ANSI_REPLACEMENTS) {
+      clean = clean.replace(pattern, "");
+    }
   }
 
-  // Strip terminal control chars like carriage return/backspace that can
-  // corrupt TUI layout when rendered back into pi.
-  return Array.from(clean)
-    .filter((char) => {
-      const code = char.codePointAt(0) ?? 0;
-      const isDisallowedC0 =
-        (code >= 0x00 && code <= 0x08) ||
-        (code >= 0x0b && code <= 0x1f) ||
-        code === 0x7f;
-      return !isDisallowedC0;
-    })
-    .join("");
+  return clean.replace(TERMINAL_CONTROL_CHARS, "");
 }


### PR DESCRIPTION
## Summary
- strip non-printing terminal control chars like carriage return and backspace in `stripAnsi()`
- sanitize the collapsed log dock preview before rendering it
- add regression tests for ANSI/control-char stripping

## Why
Some process output includes spinner/progress style control bytes such as bare `
` or ``. Those bytes can make pi's TUI render orphaned, repeated, or cascading lines when log content is rendered back into widgets/components.

This keeps the current output capture behavior intact, but hardens the render/sanitization path so control characters do not leak into the TUI.

## Verification
- `npx pnpm test`
- `npx pnpm typecheck`
- `npx pnpm lint`

Testing with a proc which helps repro this issue (one of various cases, but this is an extreme one for demo purposes):


```
i=0; while true; do i=$((i+1)); printf '\033[1A\033[2K\033[G[UP-REPRO %04d] this line tries to move the cursor up before rendering preview %s %s %s %s %s\n' "$i" alpha bravo charlie delta echo >&2; sleep 0.2; done
```


Before: 

<img width="787" height="1012" alt="image" src="https://github.com/user-attachments/assets/146d755a-64c1-492a-8ca2-4d406439d170" />


After:

<img width="782" height="1002" alt="image" src="https://github.com/user-attachments/assets/5be7fbba-4ef7-4ca5-8270-9540202951f3" />
