### PR TITLE
Fix collapsed dock wrapping

### DIFF
--- a/.changeset/fuzzy-docks-breathe.md
+++ b/.changeset/fuzzy-docks-breathe.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-processes": patch
+---
+
+Leave one terminal column unused in the collapsed log dock so long process output does not wrap into the editor.

--- a/src/components/log-dock-component.test.ts
+++ b/src/components/log-dock-component.test.ts
@@ -1,0 +1,29 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { renderCollapsedDockLine } from "./log-dock-component";
+
+const CIRCLECI_LINE =
+  "run-cm-be-tests - db5d24ee pending ↻ https://app.circleci.com/pipelines/gh/coursedog/coursedogv3/106313/workflows/f68e6db3-667d-48a0-ac75-d34be7c17e09?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link";
+
+describe("renderCollapsedDockLine", () => {
+  it("leaves a spare terminal column for long log lines", () => {
+    for (const width of [1, 2, 40, 80, 120]) {
+      const rendered = renderCollapsedDockLine(CIRCLECI_LINE, width);
+
+      expect(visibleWidth(rendered)).toBe(width - 1);
+    }
+  });
+
+  it("leaves a spare terminal column for ansi-styled log lines", () => {
+    const rendered = renderCollapsedDockLine(
+      `\u001b[2m${CIRCLECI_LINE}\u001b[22m`,
+      80,
+    );
+
+    expect(visibleWidth(rendered)).toBe(79);
+  });
+
+  it("renders nothing for zero width", () => {
+    expect(renderCollapsedDockLine(CIRCLECI_LINE, 0)).toBe("");
+  });
+});

--- a/src/components/log-dock-component.test.ts
+++ b/src/components/log-dock-component.test.ts
@@ -2,13 +2,13 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { renderCollapsedDockLine } from "./log-dock-component";
 
-const CIRCLECI_LINE =
-  "run-cm-be-tests - db5d24ee pending ↻ https://app.circleci.com/pipelines/gh/coursedog/coursedogv3/106313/workflows/f68e6db3-667d-48a0-ac75-d34be7c17e09?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link";
+const LONG_LOG_LINE =
+  "build-step - 3f7a9c2 pending ↻ https://example.com/pipelines/project/service/123456/workflows/abcdef12-3456-7890-abcd-ef1234567890/jobs/integration-test?token=very-long-unbroken-log-segment-and-query-string";
 
 describe("renderCollapsedDockLine", () => {
   it("leaves a spare terminal column for long log lines", () => {
     for (const width of [1, 2, 40, 80, 120]) {
-      const rendered = renderCollapsedDockLine(CIRCLECI_LINE, width);
+      const rendered = renderCollapsedDockLine(LONG_LOG_LINE, width);
 
       expect(visibleWidth(rendered)).toBe(width - 1);
     }
@@ -16,7 +16,7 @@ describe("renderCollapsedDockLine", () => {
 
   it("leaves a spare terminal column for ansi-styled log lines", () => {
     const rendered = renderCollapsedDockLine(
-      `\u001b[2m${CIRCLECI_LINE}\u001b[22m`,
+      `\u001b[2m${LONG_LOG_LINE}\u001b[22m`,
       80,
     );
 
@@ -24,6 +24,6 @@ describe("renderCollapsedDockLine", () => {
   });
 
   it("renders nothing for zero width", () => {
-    expect(renderCollapsedDockLine(CIRCLECI_LINE, 0)).toBe("");
+    expect(renderCollapsedDockLine(LONG_LOG_LINE, 0)).toBe("");
   });
 });

--- a/src/components/log-dock-component.ts
+++ b/src/components/log-dock-component.ts
@@ -29,6 +29,24 @@ const PROCESS_COLORS: ThemeColor[] = [
   "warning",
 ];
 
+const COLLAPSED_DOCK_RIGHT_MARGIN = 1;
+
+function getCollapsedDockLineWidth(width: number): number {
+  return Math.max(0, width - COLLAPSED_DOCK_RIGHT_MARGIN);
+}
+
+export function renderCollapsedDockLine(
+  content: string,
+  width: number,
+): string {
+  const lineWidth = getCollapsedDockLineWidth(width);
+  if (lineWidth === 0) return "";
+
+  const innerWidth = Math.max(0, lineWidth - 2);
+  const line = truncateToWidth(content, innerWidth, "", true);
+  return ` ${line}${" ".repeat(Math.max(0, lineWidth - 1 - visibleWidth(line)))}`;
+}
+
 interface LogDockOptions {
   manager: ProcessManager;
   theme: Theme;
@@ -120,17 +138,12 @@ export class LogDockComponent implements Component {
     const fg = (color: ThemeColor, s: string) => theme.fg(color, s);
 
     const processes = this.manager.list();
-    const innerWidth = width - 2;
-    const padLine = (content: string) => {
-      const line =
-        visibleWidth(content) > innerWidth
-          ? truncateToWidth(content, innerWidth, "", true)
-          : content;
-      return ` ${line}${" ".repeat(Math.max(0, width - 1 - visibleWidth(line)))}`;
-    };
+    const lineWidth = getCollapsedDockLineWidth(width);
+    const padLine = (content: string) =>
+      renderCollapsedDockLine(content, width);
 
     if (processes.length === 0) {
-      return [renderPanelRule(width, theme), padLine(dim("No processes"))];
+      return [renderPanelRule(lineWidth, theme), padLine(dim("No processes"))];
     }
 
     const running = processes.filter((p) => LIVE_STATUSES.has(p.status));
@@ -146,20 +159,12 @@ export class LogDockComponent implements Component {
     }
 
     const firstLine = parts.join(" | ");
-    const lines = [
-      renderPanelRule(width, theme),
-      padLine(truncateToWidth(firstLine, innerWidth, "", true)),
-    ];
+    const lines = [renderPanelRule(lineWidth, theme), padLine(firstLine)];
 
     if (running.length > 0) {
       const lastLogs = this.manager.getCombinedOutput(running[0].id, 1);
       if (lastLogs && lastLogs.length > 0) {
-        const lastLog = truncateToWidth(
-          stripAnsi(lastLogs[lastLogs.length - 1].text),
-          innerWidth,
-          "",
-          true,
-        );
+        const lastLog = stripAnsi(lastLogs[lastLogs.length - 1].text);
         lines.push(padLine(dim(lastLog)));
       }
     }


### PR DESCRIPTION
## Problem

Long single-line process output can make the collapsed log dock hit the terminal right edge. In the screenshot, the dock row containing the CI URL is the `pi-processes`-owned part of the layout.

Before screenshot: 
<img width="3456" height="1914" alt="pi-processes-broken-layout-redacted" src="https://github.com/user-attachments/assets/ebaeb757-4b09-4c29-bba3-0a0f91cf68eb" />


## Scope note

The repeated loading/thinking rows above the dock are rendered by Pi core, not `pi-processes`. This PR does **not** claim to fix that part directly. It only removes right-edge pressure from the collapsed dock so the dock is not the source of terminal wrapping/overpaint at the bottom of the layout. If the loading rows still duplicate/misplace without dock wrapping, that likely needs a separate Pi TUI/core fix.

## Cause

The collapsed dock padded rows to the full terminal width. That is risky at the terminal right edge when logs contain very long unbroken strings such as CI URLs.

## Fix

- Reserve one right-edge terminal column in collapsed dock rows.
- Centralize collapsed-row truncation/padding in `renderCollapsedDockLine`.
- Keep open dock rendering unchanged.
- Add regression coverage for long CircleCI-style log lines, ANSI-styled lines, and narrow widths.

## Verification

- Confirmed latest upstream/published version is `v0.9.1`; no released fix present.
- `pnpm vitest run src/components/log-dock-component.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
