### PR TITLE
fix: support OMP renderer argument order

### DIFF
--- a/.changeset/calm-process-renderer.md
+++ b/.changeset/calm-process-renderer.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-processes": patch
+---
+
+Pass render options and theme to process call renderers in host contract order.

--- a/src/tools/index.test.ts
+++ b/src/tools/index.test.ts
@@ -1,0 +1,48 @@
+import type {
+  ExtensionAPI,
+  Theme,
+  ToolRenderResultOptions,
+} from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import type { ProcessManager } from "../manager";
+import { setupProcessesTools } from ".";
+
+describe("process tool renderer", () => {
+  function setupRenderer() {
+    let renderCall: ((...args: unknown[]) => Component) | undefined;
+    const pi = {
+      registerTool(tool: { renderCall?: (...args: unknown[]) => Component }) {
+        renderCall = tool.renderCall;
+      },
+    } as unknown as ExtensionAPI;
+    const options = {
+      expanded: false,
+      isPartial: false,
+    } as ToolRenderResultOptions;
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+    } as Theme;
+
+    setupProcessesTools(pi, {} as ProcessManager);
+
+    return { options, renderCall, theme };
+  }
+
+  it("renders with OMP argument order", () => {
+    const { options, renderCall, theme } = setupRenderer();
+
+    expect(
+      renderCall?.({ action: "list" }, options, theme).render(80).join("\n"),
+    ).toContain("Process:");
+  });
+
+  it("renders with Earendil argument order", () => {
+    const { options, renderCall, theme } = setupRenderer();
+
+    expect(
+      renderCall?.({ action: "list" }, theme, options).render(80).join("\n"),
+    ).toContain("Process:");
+  });
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -98,7 +98,7 @@ const ProcessesParams = Type.Object({
           stream: Type.Optional(
             StringEnum(["stdout", "stderr", "both"] as const, {
               description:
-                "Which stream to watch (default: both). Use stdout/stderr to reduce noise.",
+                "Which stream to watch (default both). Use stdout/stderr to reduce noise.",
             }),
           ),
           repeat: Type.Optional(
@@ -141,7 +141,7 @@ ${
     ? "- debug_preview: Temporary renderer preview for process tool UIs (no process side effects)\n  - preview: start | list | output | logs | error (default: start)\n"
     : ""
 }
-Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue with other work - you'll be informed if something requires attention.
+Important: You DON'T need to poll or wait for processes. Notifications arrive automatically based on your preferences. Start processes and continue other work - you'll be informed if something requires attention.
 
 Note: User always sees process updates in the UI. The notify flags control whether YOU (the agent) get a turn to react (e.g. check results, fix code, restart).`,
     promptSnippet:
@@ -159,8 +159,16 @@ Note: User always sees process updates in the UI. The notify flags control wheth
       return executeAction(params, manager, ctx);
     },
 
-    renderCall(args: ProcessesParamsType, theme: Theme, _context) {
-      return renderActionCall(args, theme);
+    renderCall(
+      args: ProcessesParamsType,
+      theme: Theme,
+      options: ToolRenderResultOptions,
+    ) {
+      const resolvedTheme =
+        typeof theme.bold === "function"
+          ? theme
+          : (options as unknown as Theme);
+      return renderActionCall(args, resolvedTheme);
     },
 
     renderResult(


### PR DESCRIPTION
## Summary

- accept OMP's `(args, options, theme)` `renderCall` invocation
- preserve Earendil's declared `(args, theme, options)` contract
- add regression coverage for both host argument orders
- include patch changeset for release

## Root cause

OMP passes render options before theme. `pi-processes` treated the options object as `Theme`, then `ToolCallHeader` called `th.bold(...)` and crashed because `bold` was undefined.

## Verification

- `pnpm vitest run src/tools/index.test.ts` — 2 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed