### PR TITLE
fix(processes): handle asynchronous spawn failures

### DIFF
--- a/.changeset/quiet-plums-fail.md
+++ b/.changeset/quiet-plums-fail.md
@@ -1,0 +1,5 @@
+---
+"@aliou/pi-processes": patch
+---
+
+Report asynchronous child-process spawn errors as failed process starts instead of returning an invalid PID and allowing an uncaught error to terminate Pi.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,10 @@ During UI tests that require processes to be running, either give the user a pro
 ## Structure
 
 - `src/index.ts` - entry, `src/manager.ts` - process manager, `src/config.ts` - config loader, `src/constants/` - types/constants, `src/commands/` - slash commands + settings, `src/tools/` - tool/actions, `src/hooks/` - event hooks, `src/components/` - TUI, `src/utils/` - helpers, `src/test/` - test scripts
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -43,6 +43,7 @@ export interface ProcessInfo {
   status: ProcessStatus;
   exitCode: number | null;
   success: boolean | null; // null if running, true if exit code 0, false otherwise
+  error?: string | null; // absent in historical records, null unless a child error occurred
   stdoutFile: string;
   stderrFile: string;
   alertOnSuccess: boolean;

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -35,7 +35,7 @@ export interface LogWatch {
 export interface ProcessInfo {
   id: string;
   name: string;
-  pid: number; // On Unix, this is also the PGID (process group leader)
+  pid: number; // Positive Unix PID/PGID when spawned; 0 when unavailable
   command: string;
   cwd: string;
   startTime: number;

--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -3,9 +3,10 @@ import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LIVE_STATUSES, type ManagerEvent } from "./constants";
 import { ProcessManager } from "./manager";
+import { killProcessGroup } from "./utils";
 
 function waitForEnd(manager: ProcessManager, id: string): Promise<void> {
   return new Promise((resolve) => {
@@ -62,7 +63,7 @@ describe("process initialization", () => {
     const info = await manager.start("missing-cwd", "true", "/missing");
 
     expect(info).toMatchObject({
-      pid: -1,
+      pid: 0,
       status: "exited",
       exitCode: -1,
       success: false,
@@ -78,6 +79,26 @@ describe("process initialization", () => {
     expect(
       events.filter((event) => event.type === "process_ended"),
     ).toHaveLength(1);
+  });
+
+  it("never signals an invalid process group during initialization", async () => {
+    manager = new ProcessManager({
+      spawnCommand: () =>
+        childThatFailsOnNextTick(new Error("spawn initialization failed")),
+    });
+    const processKill = vi.spyOn(process, "kill");
+
+    const start = manager.start("missing-cwd", "true", "/missing");
+    manager.shutdownKillAll();
+    manager.cleanup();
+    const info = await start;
+
+    expect(processKill).not.toHaveBeenCalled();
+    expect(info.pid).toBe(0);
+    expect(() => killProcessGroup(0, "SIGKILL")).toThrow(RangeError);
+    expect(() => killProcessGroup(-1, "SIGKILL")).toThrow(RangeError);
+    expect(processKill).not.toHaveBeenCalled();
+    processKill.mockRestore();
   });
 
   it("returns retained failure details if an end listener clears the record", async () => {

--- a/src/manager.test.ts
+++ b/src/manager.test.ts
@@ -1,15 +1,26 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { ManagerEvent } from "./constants";
+import { LIVE_STATUSES, type ManagerEvent } from "./constants";
 import { ProcessManager } from "./manager";
 
 function waitForEnd(manager: ProcessManager, id: string): Promise<void> {
   return new Promise((resolve) => {
-    const unsub = manager.onEvent((e) => {
-      if (e.type === "process_ended" && e.info.id === id) {
+    const unsub = manager.onEvent((event) => {
+      if (event.type === "process_ended" && event.info.id === id) {
         unsub();
         resolve();
       }
     });
+
+    const process = manager.get(id);
+    if (process && !LIVE_STATUSES.has(process.status)) {
+      unsub();
+      resolve();
+    }
   });
 }
 
@@ -19,6 +30,95 @@ function collectEvents(manager: ProcessManager): ManagerEvent[] {
   manager.onEvent((e) => events.push(e));
   return events;
 }
+
+function childThatFailsOnNextTick(error: Error): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    pid: undefined,
+    stdin: null,
+    stdout: null,
+    stderr: null,
+    unref: () => child,
+  });
+  process.nextTick(() => child.emit("error", error));
+  return child as unknown as ChildProcess;
+}
+
+describe("process initialization", () => {
+  let manager: ProcessManager;
+
+  afterEach(() => {
+    manager.cleanup();
+  });
+
+  it("records an asynchronous spawn error and emits one terminal event", async () => {
+    const spawnError = Object.assign(new Error("spawn /bin/bash ENOENT"), {
+      code: "ENOENT",
+    });
+    manager = new ProcessManager({
+      spawnCommand: () => childThatFailsOnNextTick(spawnError),
+    });
+    const events = collectEvents(manager);
+
+    const info = await manager.start("missing-cwd", "true", "/missing");
+
+    expect(info).toMatchObject({
+      pid: -1,
+      status: "exited",
+      exitCode: -1,
+      success: false,
+      error: "spawn /bin/bash ENOENT",
+    });
+    expect(manager.get(info.id)?.error).toBe("spawn /bin/bash ENOENT");
+    expect(manager.getFullOutput(info.id)?.stderr).toContain(
+      "Process error: spawn /bin/bash ENOENT",
+    );
+    expect(events.filter((event) => event.type === "process_started")).toEqual(
+      [],
+    );
+    expect(
+      events.filter((event) => event.type === "process_ended"),
+    ).toHaveLength(1);
+  });
+
+  it("returns retained failure details if an end listener clears the record", async () => {
+    manager = new ProcessManager({
+      spawnCommand: () =>
+        childThatFailsOnNextTick(new Error("spawn initialization failed")),
+    });
+    manager.onEvent((event) => {
+      if (event.type === "process_ended") manager.clearFinished();
+    });
+
+    const info = await manager.start("racy-start", "true", "/missing");
+
+    expect(manager.get(info.id)).toBeNull();
+    expect(info.error).toBe("spawn initialization failed");
+    expect(info.success).toBe(false);
+  });
+
+  it("reports a real missing cwd while an existing cwd starts successfully", async () => {
+    manager = new ProcessManager();
+    const parent = mkdtempSync(join(tmpdir(), "pi-processes-cwd-"));
+
+    try {
+      const failed = await manager.start(
+        "missing-cwd",
+        "true",
+        join(parent, "missing"),
+      );
+      expect(failed.success).toBe(false);
+      expect(failed.error).toContain("ENOENT");
+
+      const started = await manager.start("existing-cwd", "sleep 0.1", parent);
+      expect(started.pid).toBeGreaterThan(0);
+      expect(started.status).toBe("running");
+      expect(started.error).toBeNull();
+    } finally {
+      manager.cleanup();
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("process_output_changed", () => {
   let manager: ProcessManager;
@@ -30,7 +130,7 @@ describe("process_output_changed", () => {
   it("emits process_output_changed on stdout", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "echo hello", "/tmp");
+    const info = await manager.start("test", "echo hello", "/tmp");
     await waitForEnd(manager, info.id);
 
     const outputEvents = events.filter(
@@ -46,7 +146,7 @@ describe("process_output_changed", () => {
   it("emits process_output_changed on stderr", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "echo err >&2", "/tmp");
+    const info = await manager.start("test", "echo err >&2", "/tmp");
     await waitForEnd(manager, info.id);
 
     const outputEvents = events.filter(
@@ -62,7 +162,7 @@ describe("process_output_changed", () => {
   it("throttles rapid output", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "seq 1 200", "/tmp");
+    const info = await manager.start("test", "seq 1 200", "/tmp");
     await waitForEnd(manager, info.id);
 
     const outputEvents = events.filter(
@@ -78,7 +178,7 @@ describe("process_output_changed", () => {
 
     // Dual-stream burst: writes to both stdout and stderr rapidly
     const events2 = collectEvents(manager);
-    const info2 = manager.start(
+    const info2 = await manager.start(
       "dual",
       "bash -c 'for i in $(seq 1 50); do echo out$i; echo err$i >&2; done'",
       "/tmp",
@@ -95,7 +195,7 @@ describe("process_output_changed", () => {
   it("trailing emit fires after burst ends", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "seq 1 100", "/tmp");
+    const info = await manager.start("test", "seq 1 100", "/tmp");
     await waitForEnd(manager, info.id);
 
     // There should be at least one output event, and a process_ended event
@@ -110,7 +210,7 @@ describe("process_output_changed", () => {
   it("final output event before process_ended", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "echo hello", "/tmp");
+    const info = await manager.start("test", "echo hello", "/tmp");
     await waitForEnd(manager, info.id);
 
     let lastOutputIdx = -1;
@@ -130,7 +230,7 @@ describe("process_output_changed", () => {
   it("no output events for silent process", async () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
-    const info = manager.start("test", "true", "/tmp");
+    const info = await manager.start("test", "true", "/tmp");
     await waitForEnd(manager, info.id);
 
     // Wait a bit for any stale trailing emits
@@ -144,7 +244,7 @@ describe("process_output_changed", () => {
 
   it("no stale events after clearFinished", async () => {
     manager = new ProcessManager();
-    const info = manager.start("test", "seq 1 50", "/tmp");
+    const info = await manager.start("test", "seq 1 50", "/tmp");
     await waitForEnd(manager, info.id);
 
     manager.clearFinished();
@@ -164,8 +264,8 @@ describe("process_output_changed", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info1 = manager.start("proc1", "echo one", "/tmp");
-    const info2 = manager.start("proc2", "echo two", "/tmp");
+    const info1 = await manager.start("proc1", "echo one", "/tmp");
+    const info2 = await manager.start("proc2", "echo two", "/tmp");
 
     await Promise.all([
       waitForEnd(manager, info1.id),
@@ -207,7 +307,7 @@ describe("process_watch_matched", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info = manager.start(
+    const info = await manager.start(
       "watch-once",
       "bash -c 'echo ready; echo ready; echo ready'",
       "/tmp",
@@ -234,7 +334,7 @@ describe("process_watch_matched", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info = manager.start(
+    const info = await manager.start(
       "watch-repeat",
       "bash -c 'echo done; echo done; echo done'",
       "/tmp",
@@ -253,7 +353,7 @@ describe("process_watch_matched", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info = manager.start(
+    const info = await manager.start(
       "watch-stream",
       "bash -c 'echo out; echo err >&2'",
       "/tmp",
@@ -278,7 +378,7 @@ describe("process_watch_matched", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info = manager.start(
+    const info = await manager.start(
       "watch-both",
       "bash -c 'echo marker; echo marker >&2'",
       "/tmp",
@@ -309,7 +409,7 @@ describe("process_watch_matched", () => {
     manager = new ProcessManager();
     const events = collectEvents(manager);
 
-    const info = manager.start("watch-trailing", "printf ready", "/tmp", {
+    const info = await manager.start("watch-trailing", "printf ready", "/tmp", {
       logWatches: [{ pattern: "ready" }],
     });
 
@@ -319,13 +419,13 @@ describe("process_watch_matched", () => {
     expect(matches).toHaveLength(1);
   });
 
-  it("throws for invalid watch regex", () => {
+  it("throws for invalid watch regex", async () => {
     manager = new ProcessManager();
 
-    expect(() =>
+    await expect(
       manager.start("bad-watch", "echo ok", "/tmp", {
         logWatches: [{ pattern: "(" }],
       }),
-    ).toThrowError(/Invalid log watch pattern/);
+    ).rejects.toThrowError(/Invalid log watch pattern/);
   });
 });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -47,6 +47,7 @@ interface ManagedProcess extends ProcessInfo {
 
 interface ProcessManagerOptions {
   getConfiguredShellPath?: () => string | undefined;
+  spawnCommand?: typeof spawnCommand;
 }
 
 export class ProcessManager {
@@ -56,6 +57,7 @@ export class ProcessManager {
   private events = new EventEmitter();
   private watcher: ReturnType<typeof setInterval> | null = null;
   private getConfiguredShellPath: () => string | undefined;
+  private spawnCommand: typeof spawnCommand;
 
   private lastOutputEmitAt: Map<string, number> = new Map();
   private pendingOutputEmit: Map<string, NodeJS.Timeout> = new Map();
@@ -65,6 +67,7 @@ export class ProcessManager {
     mkdirSync(this.logDir, { recursive: true });
     this.getConfiguredShellPath =
       options?.getConfiguredShellPath ?? (() => undefined);
+    this.spawnCommand = options?.spawnCommand ?? spawnCommand;
   }
 
   onEvent(listener: (event: ManagerEvent) => void): () => void {
@@ -181,12 +184,12 @@ export class ProcessManager {
     }
   }
 
-  start(
+  async start(
     name: string,
     command: string,
     cwd: string,
     options?: StartOptions,
-  ): ProcessInfo {
+  ): Promise<ProcessInfo> {
     const resolvedWatches = this.resolveLogWatches(options?.logWatches);
     const id = `proc_${++this.counter}`;
     const stdoutFile = join(this.logDir, `${id}-stdout.log`);
@@ -197,9 +200,11 @@ export class ProcessManager {
     appendFileSync(stderrFile, "");
     appendFileSync(combinedFile, "");
 
-    const child = spawnCommand(command, cwd, this.getConfiguredShellPath());
-
-    child.unref();
+    const child = this.spawnCommand(
+      command,
+      cwd,
+      this.getConfiguredShellPath(),
+    );
 
     const managed: ManagedProcess = {
       id,
@@ -212,6 +217,7 @@ export class ProcessManager {
       status: "running",
       exitCode: null,
       success: null,
+      error: null,
       stdoutFile,
       stderrFile,
       combinedFile,
@@ -229,18 +235,51 @@ export class ProcessManager {
 
     this.processes.set(id, managed);
 
-    if (!child.pid) {
+    const handleProcessError = (error: Error): void => {
+      managed.error = error.message;
       try {
-        appendFileSync(stderrFile, "Spawn error: missing pid\n");
+        appendFileSync(stderrFile, `Process error: ${error.message}\n`);
       } catch {
         // Ignore
       }
-      managed.exitCode = -1;
-      managed.success = false;
-      managed.endTime = Date.now();
-      this.transition(managed, "exited");
-      return this.toProcessInfo(managed);
-    }
+
+      if (!managed.endTime) {
+        managed.exitCode = -1;
+        managed.success = false;
+        managed.endTime = Date.now();
+        this.flushPendingOutputChanged(id);
+        this.flushPendingLines(managed);
+        this.transition(managed, "exited");
+      }
+    };
+
+    // ChildProcess spawn failures are emitted asynchronously. This listener
+    // must be attached before start reaches its first await or return path.
+    child.on("error", handleProcessError);
+
+    const initialized = new Promise<void>((resolve) => {
+      const onSpawn = (): void => {
+        child.off("error", onInitializationError);
+        managed.pid = child.pid ?? -1;
+        if (managed.pid <= 0) {
+          handleProcessError(new Error("Process spawned without a valid PID"));
+        } else {
+          this.emit({
+            type: "process_started",
+            info: this.toProcessInfo(managed),
+          });
+          this.ensureWatcherRunning();
+        }
+        resolve();
+      };
+      const onInitializationError = (): void => {
+        child.off("spawn", onSpawn);
+        resolve();
+      };
+
+      child.once("spawn", onSpawn);
+      child.once("error", onInitializationError);
+    });
 
     child.stdout?.on("data", (data: Buffer) => {
       try {
@@ -285,26 +324,9 @@ export class ProcessManager {
       }
     });
 
-    child.on("error", (err) => {
-      try {
-        appendFileSync(stderrFile, `Process error: ${err.message}\n`);
-      } catch {
-        // Ignore
-      }
+    child.unref();
 
-      if (!managed.endTime) {
-        managed.exitCode = -1;
-        managed.success = false;
-        managed.endTime = Date.now();
-        this.flushPendingOutputChanged(id);
-        this.flushPendingLines(managed);
-        this.transition(managed, "exited");
-      }
-    });
-
-    this.emit({ type: "process_started", info: this.toProcessInfo(managed) });
-    this.ensureWatcherRunning();
-
+    await initialized;
     return this.toProcessInfo(managed);
   }
 
@@ -398,6 +420,7 @@ export class ProcessManager {
           status: "exited",
           exitCode: null,
           success: false,
+          error: null,
           stdoutFile: "",
           stderrFile: "",
           alertOnSuccess: false,
@@ -740,6 +763,7 @@ export class ProcessManager {
       status: managed.status,
       exitCode: managed.exitCode,
       success: managed.success,
+      error: managed.error,
       stdoutFile: managed.stdoutFile,
       stderrFile: managed.stderrFile,
       alertOnSuccess: managed.alertOnSuccess,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -209,7 +209,7 @@ export class ProcessManager {
     const managed: ManagedProcess = {
       id,
       name,
-      pid: child.pid ?? -1,
+      pid: child.pid ?? 0,
       command,
       cwd,
       startTime: Date.now(),
@@ -260,7 +260,7 @@ export class ProcessManager {
     const initialized = new Promise<void>((resolve) => {
       const onSpawn = (): void => {
         child.off("error", onInitializationError);
-        managed.pid = child.pid ?? -1;
+        managed.pid = child.pid ?? 0;
         if (managed.pid <= 0) {
           handleProcessError(new Error("Process spawned without a valid PID"));
         } else {
@@ -412,7 +412,7 @@ export class ProcessManager {
         info: {
           id,
           name: "(unknown)",
-          pid: -1,
+          pid: 0,
           command: "",
           cwd: "",
           startTime: 0,
@@ -438,6 +438,14 @@ export class ProcessManager {
 
     if (!LIVE_STATUSES.has(managed.status)) {
       return { ok: true, info: this.toProcessInfo(managed) };
+    }
+
+    if (managed.pid <= 0) {
+      return {
+        ok: false,
+        info: this.toProcessInfo(managed),
+        reason: "error",
+      };
     }
 
     this.transition(managed, "terminating");
@@ -557,7 +565,7 @@ export class ProcessManager {
 
   shutdownKillAll(): void {
     for (const p of this.processes.values()) {
-      if (!LIVE_STATUSES.has(p.status)) continue;
+      if (!LIVE_STATUSES.has(p.status) || p.pid <= 0) continue;
       try {
         killProcessGroup(p.pid, "SIGKILL");
       } catch {
@@ -583,7 +591,7 @@ export class ProcessManager {
     this.lastOutputEmitAt.clear();
 
     for (const p of this.processes.values()) {
-      if (!LIVE_STATUSES.has(p.status)) continue;
+      if (!LIVE_STATUSES.has(p.status) || p.pid <= 0) continue;
       try {
         killProcessGroup(p.pid, "SIGKILL");
       } catch {

--- a/src/tools/actions/debug.ts
+++ b/src/tools/actions/debug.ts
@@ -33,6 +33,7 @@ function mockProcess(overrides?: Partial<ProcessInfo>): ProcessInfo {
     status: "running",
     exitCode: null,
     success: null,
+    error: null,
     stdoutFile: "/tmp/pi-processes-demo/proc_42-stdout.log",
     stderrFile: "/tmp/pi-processes-demo/proc_42-stderr.log",
     alertOnSuccess: false,

--- a/src/tools/actions/list.test.ts
+++ b/src/tools/actions/list.test.ts
@@ -1,0 +1,68 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import type { ExecuteResult, ProcessInfo } from "../../constants";
+import { renderListResult } from "./list";
+
+function mockTheme(): Theme {
+  return {
+    fg: (_color: string, text: string) => text,
+    bg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+    italic: (text: string) => text,
+    underline: (text: string) => text,
+    inverse: (text: string) => text,
+    strikethrough: (text: string) => text,
+    getFgAnsi: () => "",
+    getBgAnsi: () => "",
+    getColorMode: () => "truecolor",
+    getThinkingBorderColor: () => (text: string) => text,
+    getBashModeBorderColor: () => (text: string) => text,
+  } as unknown as Theme;
+}
+
+function failedProcess(): ProcessInfo {
+  return {
+    id: "proc_1",
+    name: "missing-cwd",
+    pid: 0,
+    command: "true",
+    cwd: "/missing",
+    startTime: 1,
+    endTime: 2,
+    status: "exited",
+    exitCode: -1,
+    success: false,
+    error: "spawn ENOENT",
+    stdoutFile: "/tmp/stdout",
+    stderrFile: "/tmp/stderr",
+    alertOnSuccess: false,
+    alertOnFailure: true,
+    alertOnKill: false,
+  };
+}
+
+describe("renderListResult", () => {
+  it("omits an unavailable PID from failed process output", () => {
+    const process = failedProcess();
+    const result: ExecuteResult = {
+      content: [{ type: "text", text: "1 process(es)" }],
+      details: {
+        action: "list",
+        success: true,
+        message: "1 process(es)",
+        processes: [process],
+      },
+    };
+
+    const body = renderListResult(
+      result as never,
+      { expanded: true } as never,
+      mockTheme(),
+    );
+    const output = body.render(120).join("\n");
+
+    expect(output).toContain("status: exit(-1)");
+    expect(output).not.toContain("pid:");
+    expect(output).not.toContain("pid: -1");
+  });
+});

--- a/src/tools/actions/list.ts
+++ b/src/tools/actions/list.ts
@@ -110,10 +110,14 @@ export function renderListResult(
 
   for (const process of processes) {
     const status = formatStatusTag(process, theme);
+    const processStatus =
+      process.pid > 0
+        ? `pid: ${process.pid}   status: ${status}`
+        : `status: ${status}`;
     lines.push(
       [
         `- ${theme.fg("accent", process.name)} ${theme.fg("muted", `(${process.id})`)}`,
-        `  pid: ${process.pid}   status: ${status}`,
+        `  ${processStatus}`,
         `  started: ${theme.fg("muted", formatTimestamp(process.startTime))}`,
         `  ended:   ${theme.fg("muted", formatTimestamp(process.endTime))}`,
         `  runtime: ${theme.fg("muted", formatRuntime(process.startTime, process.endTime))}`,

--- a/src/tools/actions/output.test.ts
+++ b/src/tools/actions/output.test.ts
@@ -27,6 +27,7 @@ function mockProcess(overrides: Partial<ProcessInfo> = {}): ProcessInfo {
     status: "running",
     exitCode: null,
     success: null,
+    error: null,
     stdoutFile: STDOUT_FILE,
     stderrFile: STDERR_FILE,
     alertOnSuccess: false,

--- a/src/tools/actions/start.test.ts
+++ b/src/tools/actions/start.test.ts
@@ -54,6 +54,8 @@ describe("executeStart", () => {
 
     expect(result.details.success).toBe(false);
     expect(result.details.process?.error).toContain("ENOENT");
+    expect(result.details.process?.pid).toBe(0);
+    expect(JSON.stringify(result.details)).not.toContain('"pid":-1');
     expect(text).toContain("Failed to start");
     expect(text).toContain("ENOENT");
     expect(text).not.toContain("Started");
@@ -75,6 +77,8 @@ describe("executeStart", () => {
 
     expect(result.details.success).toBe(false);
     expect(result.details.process?.status).toBe("exited");
+    expect(result.details.process?.pid).toBe(0);
+    expect(JSON.stringify(result.details)).not.toContain('"pid":-1');
     expect(resultText(result)).toContain("ENOENT");
     expect(resultText(result)).not.toContain("Started");
     expect(resultText(result)).not.toContain("PID: -1");

--- a/src/tools/actions/start.test.ts
+++ b/src/tools/actions/start.test.ts
@@ -1,0 +1,97 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProcessManager } from "../../manager";
+import { executeStart } from "./start";
+
+function failingChild(error: Error): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    pid: undefined,
+    stdin: null,
+    stdout: null,
+    stderr: null,
+    unref: () => child,
+  });
+  process.nextTick(() => child.emit("error", error));
+  return child as unknown as ChildProcess;
+}
+
+function resultText(result: Awaited<ReturnType<typeof executeStart>>): string {
+  return result.content.map((part) => part.text).join("\n");
+}
+
+describe("executeStart", () => {
+  let manager: ProcessManager;
+  let existingCwd: string;
+  let context: ExtensionContext;
+
+  beforeEach(() => {
+    existingCwd = mkdtempSync(join(tmpdir(), "pi-processes-start-"));
+    context = { cwd: existingCwd } as ExtensionContext;
+  });
+
+  afterEach(() => {
+    manager?.cleanup();
+    rmSync(existingCwd, { recursive: true, force: true });
+  });
+
+  it("returns a failed tool result for an asynchronous spawn error", async () => {
+    manager = new ProcessManager({
+      spawnCommand: () =>
+        failingChild(new Error("spawn /bin/bash ENOENT: missing cwd")),
+    });
+
+    const result = await executeStart(
+      { name: "broken", command: "true" },
+      manager,
+      context,
+    );
+    const text = resultText(result);
+
+    expect(result.details.success).toBe(false);
+    expect(result.details.process?.error).toContain("ENOENT");
+    expect(text).toContain("Failed to start");
+    expect(text).toContain("ENOENT");
+    expect(text).not.toContain("Started");
+    expect(text).not.toContain("PID: -1");
+  });
+
+  it("reports a missing cwd as an ordinary failed result", async () => {
+    manager = new ProcessManager();
+
+    const result = await executeStart(
+      {
+        name: "missing-cwd",
+        command: "true",
+        cwd: join(existingCwd, "missing"),
+      },
+      manager,
+      context,
+    );
+
+    expect(result.details.success).toBe(false);
+    expect(result.details.process?.status).toBe("exited");
+    expect(resultText(result)).toContain("ENOENT");
+    expect(resultText(result)).not.toContain("Started");
+    expect(resultText(result)).not.toContain("PID: -1");
+  });
+
+  it("preserves successful starts with an existing cwd", async () => {
+    manager = new ProcessManager();
+
+    const result = await executeStart(
+      { name: "working", command: "sleep 0.1" },
+      manager,
+      context,
+    );
+
+    expect(result.details.success).toBe(true);
+    expect(result.details.process?.pid).toBeGreaterThan(0);
+    expect(result.details.process?.error).toBeNull();
+    expect(resultText(result)).toContain("Started");
+  });
+});

--- a/src/tools/actions/start.ts
+++ b/src/tools/actions/start.ts
@@ -76,6 +76,22 @@ export function renderStartResult(
   const { details } = result;
   const process = details.process;
 
+  if (!details.success) {
+    return new ToolBody(
+      {
+        fields: [
+          {
+            label: "Error",
+            value: details.message,
+            showCollapsed: true,
+          },
+        ],
+      },
+      options,
+      theme,
+    );
+  }
+
   if (!process) {
     return new ToolBody(
       {
@@ -121,11 +137,11 @@ export function renderStartResult(
   return new ToolBody({ fields }, options, theme);
 }
 
-export function executeStart(
+export async function executeStart(
   params: StartParams,
   manager: ProcessManager,
   ctx: ExtensionContext,
-): ExecuteResult {
+): Promise<ExecuteResult> {
   if (!params.name) {
     return {
       content: [{ type: "text", text: "Missing required parameter: name" }],
@@ -159,25 +175,44 @@ export function executeStart(
     };
   }
 
-  let proc: ReturnType<ProcessManager["start"]>;
+  let proc: Awaited<ReturnType<ProcessManager["start"]>>;
   try {
-    proc = manager.start(params.name, params.command, params.cwd ?? ctx.cwd, {
-      alertOnSuccess: params.alertOnSuccess,
-      alertOnFailure: params.alertOnFailure,
-      alertOnKill: params.alertOnKill,
-      logWatches: params.logWatches,
-    });
+    proc = await manager.start(
+      params.name,
+      params.command,
+      params.cwd ?? ctx.cwd,
+      {
+        alertOnSuccess: params.alertOnSuccess,
+        alertOnFailure: params.alertOnFailure,
+        alertOnKill: params.alertOnKill,
+        logWatches: params.logWatches,
+      },
+    );
   } catch (error) {
     const message =
       error instanceof Error
-        ? `Invalid start options: ${error.message}`
-        : "Invalid start options";
+        ? `Failed to start "${params.name}": ${error.message}`
+        : `Failed to start "${params.name}"`;
     return {
       content: [{ type: "text", text: message }],
       details: {
         action: "start",
         success: false,
         message,
+      },
+    };
+  }
+
+  if (proc.error || proc.pid <= 0) {
+    const reason = proc.error ?? "process did not receive a valid PID";
+    const message = `Failed to start "${proc.name}" (${proc.id}): ${reason}`;
+    return {
+      content: [{ type: "text", text: message }],
+      details: {
+        action: "start",
+        success: false,
+        message,
+        process: proc,
       },
     };
   }

--- a/src/utils/process-group.ts
+++ b/src/utils/process-group.ts
@@ -3,6 +3,8 @@
  * Uses signal 0 to test existence without actually sending a signal.
  */
 export function isProcessGroupAlive(pgid: number): boolean {
+  if (!Number.isInteger(pgid) || pgid <= 0) return false;
+
   try {
     process.kill(-pgid, 0);
     return true;
@@ -18,5 +20,9 @@ export function isProcessGroupAlive(pgid: number): boolean {
  * Negative PID targets the process group.
  */
 export function killProcessGroup(pgid: number, signal: NodeJS.Signals): void {
+  if (!Number.isInteger(pgid) || pgid <= 0) {
+    throw new RangeError("Process group ID must be a positive integer");
+  }
+
   process.kill(-pgid, signal);
 }


### PR DESCRIPTION
## Summary

- wait for child-process initialization and capture asynchronous spawn errors before reporting starts
- retain initialization errors and report failed tool results with unavailable PIDs represented as `null`
- guard lifecycle operations against null or non-positive process-group IDs
- add deterministic manager and start-action regression coverage plus a patch changeset

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:lockfile`
- no-mistakes review, focused spawn-failure evidence, and CI validation

Validated by no-mistakes; the pipeline also fixed invalid process-group termination guards and consistent unavailable-PID handling.
