### PR TITLE
feat(evals): add pi-evals harness and smoke eval

### DIFF
--- a/.agents/skills/sync-pi-evals/SKILL.md
+++ b/.agents/skills/sync-pi-evals/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: sync-pi-evals
+description: Vendor and refresh the unpublished pi-evals harness from earendil-works/pi into tests/evals/vendor, and keep pi-* devDependencies compatible with it. Use when asked to set up, refresh, or update the evals harness or vendored pi-evals code in pi-processes.
+---
+
+# Syncing vendored pi-evals
+
+`@earendil-works/pi-evals` (`packages/evals` in `earendil-works/pi`) is `"private": true` and not published to npm.
+Until it ships publicly, the harness source is copied into `tests/evals/vendor/pi-evals/` (gitignored) and patched.
+
+Why not a pnpm git dependency: installing `github:earendil-works/pi#<ref>&path:packages/evals` does fetch the code,
+but the harness must be patched, and `pnpm patch` on that dependency fails with
+`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` — it tries to prepare the whole `pi-monorepo` root and demands an
+`allowBuilds` entry for it. Revisit if pi publishes the package or upstreams extension injection.
+
+Do not run the eval suite as part of syncing: evals make real, paid model calls. `pnpm typecheck:evals` is the free
+check that a vendor drop is sound.
+
+## Run the script
+
+```bash
+./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh                 # pinned default ref
+./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh --ref v0.85.0   # tag, branch, or SHA
+```
+
+It clones the pi repo at the ref, copies `pi-harness.ts` and `vitest-evals/`, records the upstream `package.json`
+as `upstream-package.json`, applies every patch in `tests/evals/patches/`, and writes `tests/evals/vendor/SYNC.json`
+with the ref, resolved SHA, and date. Re-running is safe: `rsync --delete` restores pristine files before patching.
+
+The script only mechanises the copy. The two decisions below are yours.
+
+## Decision 1: which ref
+
+Read `tests/evals/vendor/SYNC.json` first to see what is currently vendored.
+
+Default rule: use the git tag matching the `@earendil-works/pi-coding-agent` version pinned in this repo's
+`package.json` devDependencies (devDependency `0.84.1` → tag `v0.84.1`). The harness calls
+`AgentSession` / `createAgentSessionServices` APIs, so it must match the coding-agent version we build against.
+
+Exception: if the harness change you need landed on `main` after the latest tag, pin the exact SHA rather than a
+branch, and check whether that commit's `packages/coding-agent` API is compatible with the version installed here.
+If it is not, stop and ask the user before syncing — see decision 2.
+
+Never sync from a floating branch. The script accepts one, but the result is not reproducible.
+
+## Decision 2: dependency reconciliation — always ask before bumping
+
+After syncing, compare `tests/evals/vendor/pi-evals/upstream-package.json` devDependencies against this repo's
+`package.json`:
+
+- `@earendil-works/pi-ai`
+- `@earendil-works/pi-coding-agent`
+- `vitest`
+- `vitest-evals` (already a devDependency here, pinned exact)
+
+Then run `pnpm typecheck:evals`. It compiles the vendored and patched harness against this repo's installed
+versions and is the real compatibility signal.
+
+If it passes and versions match: done.
+
+If versions differ or the typecheck fails:
+
+1. Report the mismatch explicitly: which package, the version pinned here, the version the vendored code expects,
+   and whether that version is published (`npm view @earendil-works/pi-coding-agent version`).
+2. If it is published: propose bumping `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`,
+   `@earendil-works/pi-tui`, and `vitest` (plus matching `peerDependencies` ranges), and ask for confirmation
+   before running `pnpm add -D <pkg>@<version>`. This repo uses pnpm. Never bump silently.
+3. If it is not published: say the vendored harness is ahead of what is installable, and ask whether to re-sync
+   from the last tag (losing the new harness feature) or wait for the next pi release.
+
+## The patches
+
+`tests/evals/patches/0001-harness-additional-resource-paths.patch` makes four changes, all required:
+
+1. adds `additionalExtensionPaths` / `additionalSkillPaths` options,
+2. always forwards `resourceLoaderOptions` (upstream only does when `transformSystemPrompt` is set),
+3. relaxes the zero-extension guard to expect exactly the injected extensions,
+4. widens `resolveModelSelection`'s `environment` parameter to `Record<string, string | undefined>`, because
+   `@types/node` 25 here makes `ProcessEnv` incompatible with upstream's inline literal type.
+
+Upstream's harness deliberately refuses to load extensions, so without 1–3 there is no way to get the processes
+extension into an eval session.
+
+If the script reports a failed patch, upstream moved. Re-derive the change by hand against the newly vendored
+`pi-harness.ts`, regenerate with `diff -u`, and commit the updated patch file. Do not skip it.
+
+## After syncing
+
+- `pnpm typecheck:evals` must pass. `pnpm typecheck` excludes `tests/evals` on purpose, so it stays green without a
+  vendor drop.
+- Verify with `git status` that nothing under `tests/evals/vendor/` is staged; it is gitignored.
+- CI runs this same script in the gated `evals` job, so a working sync locally means a working sync there.
+
+For writing, running, and verifying the evals themselves, see the `writing-pi-evals` skill and
+`tests/evals/README.md`.
+
+## Re-sync when
+
+- `@earendil-works/pi-coding-agent` is bumped here.
+- An eval needs a harness capability that only exists in a newer pi commit.
+- `SYNC.json` predates a pi release this repo has adopted.

--- a/.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh
+++ b/.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Vendor the unpublished pi-evals harness into tests/evals/vendor/pi-evals.
+#
+# @earendil-works/pi-evals is private:true and not on npm, so it is copied from
+# the pi repo at a pinned ref and patched. See the sync-pi-evals skill for ref
+# selection and dependency reconciliation, which this script does NOT do.
+#
+# Usage:
+#   sync-pi-evals.sh [--ref <tag|branch|sha>] [--repo <url>]
+#
+# Env:
+#   PI_EVALS_REF   same as --ref
+#   PI_EVALS_REPO  same as --repo
+
+set -euo pipefail
+
+DEFAULT_REF="v0.84.1"
+DEFAULT_REPO="https://github.com/earendil-works/pi"
+
+ref="${PI_EVALS_REF:-$DEFAULT_REF}"
+repo="${PI_EVALS_REPO:-$DEFAULT_REPO}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref) ref="${2:?--ref needs a value}"; shift 2 ;;
+    --repo) repo="${2:?--repo needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Repo root is three levels up: scripts/ -> sync-pi-evals/ -> skills/ -> .agents/
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+
+vendor_dir="$repo_root/tests/evals/vendor/pi-evals"
+patch_dir="$repo_root/tests/evals/patches"
+
+for cmd in git rsync; do
+  command -v "$cmd" >/dev/null || { echo "missing required command: $cmd" >&2; exit 1; }
+done
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT
+
+echo "==> Cloning $repo at $ref"
+if ! git clone --depth 1 --branch "$ref" --quiet "$repo" "$tmp" 2>/dev/null; then
+  # --branch only accepts tags and branches; fall back to a full clone for SHAs.
+  echo "    (not a tag or branch, retrying as a commit SHA)"
+  git clone --quiet "$repo" "$tmp"
+  git -C "$tmp" checkout --quiet "$ref"
+fi
+
+resolved_sha="$(git -C "$tmp" rev-parse HEAD)"
+
+src="$tmp/packages/evals/src"
+[ -f "$src/pi-harness.ts" ] || { echo "no pi-harness.ts at $ref: upstream layout changed" >&2; exit 1; }
+
+echo "==> Copying harness into tests/evals/vendor/pi-evals"
+mkdir -p "$vendor_dir"
+# No trailing slash on vitest-evals: it must stay a subdirectory, because
+# pi-harness.ts imports ./vitest-evals/artifacts.ts.
+rsync -a --delete "$src/pi-harness.ts" "$src/vitest-evals" "$vendor_dir/"
+cp "$tmp/packages/evals/package.json" "$vendor_dir/upstream-package.json"
+
+echo "==> Applying patches"
+shopt -s nullglob
+patches=("$patch_dir"/*.patch)
+shopt -u nullglob
+[ ${#patches[@]} -gt 0 ] || { echo "no patches found in $patch_dir" >&2; exit 1; }
+
+for patch in "${patches[@]}"; do
+  echo "    $(basename "$patch")"
+  if ! git apply --directory=tests/evals/vendor/pi-evals "$patch" 2>/dev/null; then
+    cat >&2 <<EOF
+
+Patch failed to apply: $patch
+Upstream moved. Re-derive it by hand against the newly vendored pi-harness.ts,
+regenerate with 'diff -u', and commit the updated patch. Do not skip it:
+tests/evals/harness.ts depends on the options it adds.
+EOF
+    exit 1
+  fi
+done
+
+cat > "$repo_root/tests/evals/vendor/SYNC.json" <<EOF
+{
+  "ref": "$ref",
+  "sha": "$resolved_sha",
+  "syncedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "==> Synced $ref ($resolved_sha)"
+echo "    Next: pnpm typecheck:evals (free), then reconcile deps per the skill."

--- a/.agents/skills/writing-pi-evals/SKILL.md
+++ b/.agents/skills/writing-pi-evals/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: writing-pi-evals
+description: Write, run, and verify behavioral evals for the processes extension using the vendored pi-evals harness. Use when adding or debugging an eval in evals/, running the eval suite, or checking whether an eval result is trustworthy.
+---
+
+# Writing pi-processes evals
+
+Evals drive a real model through a real `AgentSession` with the processes extension loaded, then assert on the
+resulting tool calls. They measure agent behaviour (does it poll? does it reach for a log watch?), not unit
+correctness. Unit behaviour belongs in `src/**/*.test.ts` and `extensions/**/*.test.ts`.
+
+Prerequisite: the vendored harness must be present at `tests/evals/vendor/pi-evals/`. If it is missing, run
+`./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh` (see the `sync-pi-evals` skill). Nothing here works
+without it.
+
+## Layout
+
+- `tests/evals/harness.ts` — committed. Wraps the vendored `createPiCodingAgentHarness` with the processes extension
+  path, plus tool-call extraction helpers. Import this, never the vendored file directly.
+- `tests/evals/*.eval.ts` — committed. One file per behaviour area.
+- `tests/evals/patches/` — committed. Patches applied to the vendored harness during sync.
+- `tests/evals/global-setup.ts` — committed. Generates `agent-dir/models.json` from `.env.test` before any run.
+- `tests/evals/README.md` — committed. Explains which files are ours and which are vendored.
+- `tests/evals/vendor/` — gitignored. Produced by `sync-pi-evals`.
+- `tests/evals/vitest.config.ts` — separate config; `include: ["tests/evals/**/*.eval.ts"]`, long timeouts, no parallelism, no
+  global mocks (the unit `vitest.config.ts` mocks `node:fs` via memfs, which would break real process spawning).
+- `tests/evals/tsconfig.json` — separate project so `pnpm typecheck` stays green when `tests/evals/vendor/` is absent.
+
+## Running
+
+```bash
+pnpm test:evals                            # whole suite
+pnpm test:evals tests/evals/smoke.eval.ts        # one file
+pnpm test:evals -t "smoke"                 # one test by name
+pnpm typecheck:evals                 # after sync or harness edits, costs nothing
+```
+
+No environment variables required. `tests/evals/vitest.config.ts` pins everything that decides which model runs:
+
+- `PI_CODING_AGENT_DIR` to `tests/evals/agent-dir/`, so runs never read or spend from your real `~/.pi/agent`.
+- `PI_PROVIDER` / `PI_MODEL` to `aperture` / `syn:small:text`, pinned rather than inherited so an ambient
+  `PI_PROVIDER=anthropic` in your shell cannot silently redirect evals at a paid account.
+
+Override with `PI_EVAL_PROVIDER` / `PI_EVAL_MODEL` — not `PI_PROVIDER`, which the config overwrites.
+
+`tests/evals/agent-dir/` is generated at run time by `global-setup.ts` and is entirely gitignored: the Aperture
+base URL is private. Set it with `cp .env.test.example .env.test`, or export `APERTURE_BASE_URL` (CI uses a
+secret, and a real env var wins over `.env.test`). Aperture is reachable over Tailscale.
+
+### Only built-in and models.json providers work
+
+The harness calls `ModelRuntime.create()` with no arguments and resolves the model *before* it builds the session,
+so providers that your normal setup registers through extensions do not exist yet. `Eval model not found:
+<provider>/<id>` means the provider needs a `providers` entry in `tests/evals/agent-dir/models.json`, not an extension.
+
+Run `tests/evals/smoke.eval.ts` first when you suspect the setup. It is one short round trip with thinking off and is
+the cheapest way to separate "the setup is broken" from "the agent behaved badly". Keep it that way: do not split
+it into multiple tests or add prompts that invite the model to explain itself.
+
+## Writing an eval
+
+Use `createProcessesHarness()` from `tests/evals/harness.ts`. Its `output` exposes a JSON-safe view:
+
+- `response` — final assistant text.
+- `toolCalls` — every `process` call in order, with `arguments`.
+- `bashCommands` — every `bash` command string, for catching `&` / `nohup` backgrounding.
+- `activeTools` — tool names registered in the session.
+
+Assert on `result.output`. Judges and assertions receive `output`, not the live `AgentSession`.
+
+```ts
+import { expect } from "vitest";
+import { describeEval } from "vitest-evals";
+
+import { callsWithAction, createProcessesHarness } from "./harness.ts";
+
+const harness = createProcessesHarness();
+
+describeEval("process tool: <behaviour>", { harness }, (it) => {
+  it("<expected behaviour>", async ({ run }) => {
+    const result = await run("<prompt>");
+    expect(result.output.activeTools).toContain("process");
+    expect(callsWithAction(result.output.toolCalls, "start")).toHaveLength(1);
+  });
+});
+```
+
+Multi-turn scenarios pass an array of steps. Use this to seed a bad pattern before testing recovery:
+
+```ts
+const result = await run([
+  { type: "prompt", content: "Start ... without a log watch." },
+  { type: "prompt", content: "Check its output." },
+  { type: "prompt", content: "Check its output again." },
+  { type: "prompt", content: "You keep checking by hand. Fix that." },
+]);
+```
+
+`{ type: "reload" }` steps re-run resource loading, needed when a prompt created or changed Pi resources on disk.
+
+### Prefer deterministic assertions
+
+Tool discipline is mechanical: did it call `output` twice, did it pass `notify.logMatches`, did it shell out with
+`&`. Assert directly on `toolCalls` / `bashCommands`. Reserve `createJudge(...)` for genuinely fuzzy questions like
+"did it explain why it backgrounded the command", and set `judgeThreshold: null` so a low score is an observation
+rather than a suite failure.
+
+### Write prompts that make violations unambiguous
+
+A model checking output twice under a vague prompt is not misbehaviour. Say "check its output exactly once, then
+stop and end your turn" so a second call is unambiguously wrong. If you cannot phrase the prompt so a violation is
+clear-cut, the behaviour probably needs a judge, not an assertion.
+
+## Verifying an eval is trustworthy
+
+A green eval is worthless if it passed for the wrong reason. Before believing a result:
+
+1. **Guard against trivial passes.** Every eval asserts `expect(result.output.activeTools).toContain("process")`
+   and that the expected `start` call happened. Without this, "the agent never polled" also passes when the
+   extension failed to load and the agent had no `process` tool at all.
+2. **Confirm the extension count.** The patched harness throws if the number of loaded extensions does not match
+   `additionalExtensionPaths`. An error mentioning "Expected the isolated eval session to load exactly N
+   extension(s)" means the patch or the extension path is wrong, not that the agent misbehaved.
+3. **Read the transcript.** Each run writes a native Pi session JSONL under `.eval/sessions/`, indexed by
+   `.eval/runs.jsonl`. Open the session for a surprising pass or fail and read the actual tool calls. These files
+   contain prompts, responses, and tool output.
+4. **Invert the eval once.** For a new behavioural assertion, temporarily flip the prompt to induce the bad
+   behaviour (e.g. "keep checking the output until it finishes") and confirm the eval fails. An assertion that has
+   never failed has not been tested.
+5. **Repeat before concluding.** Single runs are noisy. Re-run a few times, or use `evalHarnessTable(...)` with
+   `repetitions` for comparative work, before claiming a behaviour changed.
+
+## Comparative evals
+
+To measure whether the shipped skill or a prompt change helps, build a baseline/candidate table with
+`evalHarnessTable(...)` from the vendored `tests/evals/vendor/pi-evals/vitest-evals/harness-table.ts` and Vitest's
+`describe.for(...)`. `createProcessesHarnessWithSkill()` exists as the candidate side against
+`createProcessesHarness()` as baseline. Record correctness with a judge, set `judgeThreshold: null`, and read the
+reporter's pass-rate lift rather than individual pass/fail.
+
+## Cost and etiquette
+
+Every eval run costs real tokens against a real provider. The config runs files serially with
+`maxConcurrency: 1`. Do not add retries to paper over flaky behaviour — a flaky eval is a finding. Scope runs with
+`-t` while iterating instead of running the whole suite.

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,5 @@
+# Copy to .env.test (gitignored) to run evals locally.
+#
+# Aperture is reachable over Tailscale. Do not commit the real URL.
+APERTURE_BASE_URL=http://your-aperture-host/v1
+APERTURE_API_KEY=-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
   evals:
     if: github.event_name == 'workflow_dispatch' && inputs.run_evals
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Lets the Tailscale action request an OIDC token from GitHub, which it
+      # exchanges for a short-lived Tailscale API token. No long-lived secret.
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -72,11 +77,13 @@ jobs:
         run: pnpm typecheck:evals
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          audience: ${{ secrets.TS_AUDIENCE }}
+          # Required even with one authorized tag: the action mints an ephemeral
+          # auth key via the API, and tags are a parameter of key creation.
+          tags: tag:ci-evals
 
       - name: Run evals
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_evals:
+        description: "Run the eval suite (makes real, paid model calls)"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,3 +44,42 @@ jobs:
 
       - name: E2E tests
         run: pnpm test:e2e
+
+  # Evals make real, paid model calls against Aperture over Tailscale, so they
+  # never run on push or pull_request. Trigger manually with run_evals=true.
+  evals:
+    if: github.event_name == 'workflow_dispatch' && inputs.run_evals
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # tests/evals/vendor/ is gitignored, so CI vendors the harness itself
+      # using the same script the sync-pi-evals skill runs locally.
+      - name: Vendor pi-evals harness
+        run: ./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh
+
+      - name: Typecheck evals
+        run: pnpm typecheck:evals
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Run evals
+        env:
+          APERTURE_BASE_URL: ${{ secrets.APERTURE_BASE_URL }}
+          APERTURE_API_KEY: ${{ secrets.APERTURE_API_KEY }}
+        run: pnpm test:evals

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 .env
 .env.local
 .env*.local
+.env.test
 
 # IDE
 .vscode/
@@ -38,5 +39,13 @@ result-*
 
 # Pi
 .pi/
+
+# Vendored pi-evals harness (see .pi/skills/sync-pi-evals) and eval run artifacts
+tests/evals/vendor/
+.eval/
+
+# Eval agent dir is generated at run time by tests/evals/global-setup.ts. models.json
+# embeds the private Aperture base URL, so nothing in here is committed.
+tests/evals/agent-dir/
 .agents/demos/
 .agents/plans/*.md

--- a/package.json
+++ b/package.json
@@ -67,10 +67,12 @@
     "ts-json-schema-generator": "^2.9.0",
     "typebox": "1.1.38",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "vitest-evals": "0.15.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:evals": "tsc --noEmit -p tests/evals/tsconfig.json",
     "lint": "biome check",
     "format": "biome check --write",
     "gen:schema": "ts-json-schema-generator --path extensions/processes/config/types.ts --type ProcessConfig --no-type-check -o schema.json",
@@ -81,6 +83,7 @@
     "version": "changeset version",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "test:evals": "vitest run --config tests/evals/vitest.config.ts",
     "release": "pnpm changeset publish"
   },
   "packageManager": "pnpm@11.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(yaml@2.9.0))
+      vitest-evals:
+        specifier: 0.15.0
+        version: 0.15.0(tinyrainbow@3.1.0)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(yaml@2.9.0)))(zod@3.25.76)
 
 packages:
 
@@ -1006,6 +1009,12 @@ packages:
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
+  '@vitest-evals/core@0.15.0':
+    resolution: {integrity: sha512-kqyg3ocVtZxr3rP9oh01oAycRgXNRasvTgLZ8MbFGBJ4BRd4tk7Bgww253HY7fw7ZFUp4UPYNmDp5AcHajm++w==}
+
+  '@vitest-evals/report-ui@0.15.0':
+    resolution: {integrity: sha512-icrutiRhZ2T1MrHo2RW09hcEwfi/tV/FgsGAE76Wd0C02tZyCleQRjt11RWhBJiYDPpsjjjTHGCHIO6tmtX5zQ==}
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1823,6 +1832,20 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest-evals@0.15.0:
+    resolution: {integrity: sha512-bOYALQdLXKYFRCV8aQ+yLeH7XkmYsTxUWQxLHzJdIEcIBx2v/kPgG3Zg6m231jMCphuoM6xH4YQB3+0pDP7LLw==}
+    hasBin: true
+    peerDependencies:
+      ai: '>=4 <7'
+      tinyrainbow: '>=2 <4'
+      vitest: '>=4 <5'
+      zod: '>=3 <5'
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      zod:
         optional: true
 
   vitest@4.1.5:
@@ -2929,6 +2952,14 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
+  '@vitest-evals/core@0.15.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@vitest-evals/report-ui@0.15.0':
+    dependencies:
+      '@vitest-evals/core': 0.15.0
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3697,6 +3728,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
+
+  vitest-evals@0.15.0(tinyrainbow@3.1.0)(vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(yaml@2.9.0)))(zod@3.25.76):
+    dependencies:
+      '@vitest-evals/core': 0.15.0
+      '@vitest-evals/report-ui': 0.15.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(yaml@2.9.0))
+    optionalDependencies:
+      zod: 3.25.76
 
   vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -1,0 +1,112 @@
+# Evals
+
+Behavioral, model-backed checks for the processes extension. An eval drives a real model through a real Pi
+`AgentSession` with the extension loaded, then asserts on the tool calls it made — does it poll, does it reach for
+a log watch, does it background with `&` instead of the `process` tool.
+
+Unit behavior belongs in `src/**/*.test.ts` and `extensions/**/*.test.ts`. Integration with real child processes
+belongs in `tests/e2e/`. Only agent *behavior* belongs here.
+
+Evals make real, paid model calls. They are not part of `pnpm test` and never run on push in CI.
+
+## Ours vs vendored
+
+Two kinds of code live in this directory, and the distinction matters when something breaks.
+
+### Our code (committed, edit freely)
+
+| Path | What it is |
+|---|---|
+| `harness.ts` | Wraps the vendored harness with the processes extension path and tool-call extraction helpers. Import this, never the vendored file directly. |
+| `*.eval.ts` | The evals themselves. |
+| `global-setup.ts` | Generates `agent-dir/models.json` from `.env.test` / the environment before any eval runs. |
+| `vitest.config.ts` | Eval-only Vitest config: pins the agent dir, provider, and model; long timeouts; no global mocks. |
+| `tsconfig.json` | Separate TS project so `pnpm typecheck` stays green when `vendor/` is absent. |
+| `patches/` | Patches applied to the vendored harness after each sync. |
+| `README.md` | This file. |
+
+### Vendored and patched (gitignored, never edit in place)
+
+| Path | What it is |
+|---|---|
+| `vendor/pi-evals/pi-harness.ts` | Copied from `packages/evals/src/pi-harness.ts` in `earendil-works/pi`, then patched. |
+| `vendor/pi-evals/vitest-evals/` | Copied from `packages/evals/src/vitest-evals/` — artifacts, reporter, summary, harness table. |
+| `vendor/pi-evals/upstream-package.json` | The upstream `package.json`, kept only as a dependency-version reference. |
+| `agent-dir/` | Generated at run time. Holds the private Aperture base URL, so none of it is committed. |
+
+`@earendil-works/pi-evals` is `"private": true` and not published to npm, so it cannot be installed. It is copied
+in from the pi repo at a pinned tag by:
+
+```bash
+./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh
+```
+
+CI runs that same script in the gated `evals` job. See the `sync-pi-evals` skill for ref selection and dependency
+reconciliation.
+
+Anything you change under `vendor/` is destroyed by the next sync. To change vendored behavior, edit
+`patches/0001-harness-additional-resource-paths.patch` instead, or regenerate it with `diff -u` against a clean
+copy.
+
+### Why the harness is patched at all
+
+Upstream's harness deliberately refuses to load extensions: it builds its own temp `cwd`, uses
+`SettingsManager.inMemory()`, forwards `resourceLoaderOptions` only when `transformSystemPrompt` is set, and hard
+asserts that zero extensions loaded. There is no external hook, so the patch adds
+`additionalExtensionPaths` / `additionalSkillPaths`, always forwards `resourceLoaderOptions`, and relaxes the
+guard to expect exactly the injected extensions. It also widens one `process.env` parameter type that
+`@types/node` 25 rejects.
+
+That guard is load-bearing: if the extension path is wrong, evals fail with `Expected the isolated eval session to
+load exactly 1 extension(s), got 0` rather than silently passing with no `process` tool present.
+
+## Running
+
+```bash
+pnpm test:evals                              # whole suite
+pnpm test:evals tests/evals/smoke.eval.ts    # one file
+pnpm test:evals -t "smoke"                   # one test by name
+pnpm typecheck:evals                         # free, no model calls
+```
+
+First run `pnpm typecheck:evals`; it needs the vendored harness present but costs nothing.
+
+### Configuration
+
+`vitest.config.ts` pins everything that decides which model runs, so an ambient `PI_PROVIDER=anthropic` in your
+shell cannot redirect evals at a paid account:
+
+- `PI_CODING_AGENT_DIR` → `tests/evals/agent-dir/`, never your real `~/.pi/agent`.
+- `PI_PROVIDER` / `PI_MODEL` → `aperture` / `syn:small:text`. Override with `PI_EVAL_PROVIDER` / `PI_EVAL_MODEL`.
+
+The Aperture base URL is private, and `models.json` has no environment-variable interpolation, so `global-setup.ts`
+generates that file at run time:
+
+```bash
+cp .env.test.example .env.test   # then fill in APERTURE_BASE_URL
+```
+
+A real `APERTURE_BASE_URL` in the environment wins over `.env.test`, which is how CI injects its secret. Aperture
+is reachable over Tailscale; CI connects with `tailscale/github-action` before running.
+
+Only built-in providers and those declared in the generated `models.json` work. The harness calls
+`ModelRuntime.create()` and resolves the model *before* building the session, so providers that your normal setup
+registers through extensions do not exist yet. `Eval model not found: <provider>/<id>` means it needs a `providers`
+entry, not an extension.
+
+## Verifying an eval is trustworthy
+
+A green eval is worthless if it passed for the wrong reason.
+
+1. Every eval asserts `activeTools` contains `process`. Without it, "the agent never polled" also passes when the
+   extension failed to load and there was no `process` tool at all.
+2. Invert a new eval once — flip the prompt to induce the bad behavior and confirm it fails. An assertion that has
+   never failed has not been tested.
+3. Read the transcript. Runs write native Pi session JSONL under `.eval/`, indexed by `runs.jsonl`.
+4. Repeat before concluding. Single runs are noisy.
+
+Prefer deterministic assertions on tool calls over judges. Tool discipline is mechanical; reserve `createJudge` for
+genuinely fuzzy questions and set `judgeThreshold: null` so a low score is an observation, not a suite failure.
+
+Write prompts so a violation is unambiguous. "Check its output exactly once, then stop" makes a second call clearly
+wrong; a vague prompt does not.

--- a/tests/evals/global-setup.ts
+++ b/tests/evals/global-setup.ts
@@ -1,0 +1,71 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const evalsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(evalsDir, "..", "..");
+const agentDir = join(evalsDir, "agent-dir");
+
+/**
+ * Pi resolves eval models from `<agentDir>/models.json`, a plain file with no
+ * environment-variable interpolation. The Aperture base URL is private, so the
+ * file cannot be committed. Generate it at run time instead, from `.env.test`.
+ */
+export default async function setup(): Promise<void> {
+  // Real environment wins over .env.test, so CI secrets override local files.
+  const envFile = join(repoRoot, ".env.test");
+  if (existsSync(envFile) && !process.env.APERTURE_BASE_URL) {
+    process.loadEnvFile(envFile);
+  }
+
+  const baseUrl = process.env.APERTURE_BASE_URL?.trim();
+  const apiKey = process.env.APERTURE_API_KEY?.trim() || "-";
+
+  if (!baseUrl) {
+    throw new Error(
+      [
+        "APERTURE_BASE_URL is not set, so eval models cannot be resolved.",
+        "Copy .env.test.example to .env.test and fill in your Aperture base URL,",
+        "or export APERTURE_BASE_URL in the environment (CI uses a secret).",
+      ].join(" "),
+    );
+  }
+
+  const modelsConfig = {
+    providers: {
+      aperture: {
+        name: "Aperture",
+        api: "openai-completions",
+        baseUrl,
+        apiKey,
+        models: [
+          {
+            id: "syn:small:text",
+            name: "Aperture Small (text)",
+            input: ["text"],
+            reasoning: false,
+            contextWindow: 262144,
+            // Capped deliberately: evals should never run away with output.
+            maxTokens: 4096,
+          },
+          {
+            id: "syn:large:text",
+            name: "Aperture Large (text)",
+            input: ["text"],
+            reasoning: false,
+            contextWindow: 524288,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  };
+
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    join(agentDir, "models.json"),
+    `${JSON.stringify(modelsConfig, null, 2)}\n`,
+    "utf8",
+  );
+}

--- a/tests/evals/harness.ts
+++ b/tests/evals/harness.ts
@@ -1,0 +1,122 @@
+import { fileURLToPath } from "node:url";
+
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+
+import { createPiCodingAgentHarness } from "./vendor/pi-evals/pi-harness";
+
+/**
+ * Absolute path to the processes extension entry point, loaded into the
+ * isolated eval session via the patched `additionalExtensionPaths` option.
+ */
+export const processesExtensionPath = fileURLToPath(
+  new URL("../../extensions/processes/index.ts", import.meta.url),
+);
+
+/** Absolute path to the shipped pi-processes skill. */
+export const processesSkillPath = fileURLToPath(
+  new URL("../../skills/pi-processes", import.meta.url),
+);
+
+/**
+ * Tool-call arguments as plain JSON. The vendored harness constrains its
+ * `output` to JsonValue, so everything here must stay JSON-safe.
+ */
+type JsonObject = { [key: string]: JsonValue };
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+
+export type ProcessToolCall = {
+  name: string;
+  arguments: JsonObject;
+};
+
+export type ProcessEvalOutput = {
+  response: string;
+  toolCalls: ProcessToolCall[];
+  bashCommands: string[];
+  activeTools: string[];
+};
+
+/**
+ * Harness with the processes extension loaded and no skill, so evals measure
+ * the tool description and promptGuidelines alone.
+ */
+export function createProcessesHarness(name = "processes-extension") {
+  return createPiCodingAgentHarness({
+    name,
+    additionalExtensionPaths: [processesExtensionPath],
+    output: ({ response, session }) => buildOutput(response, session),
+  });
+}
+
+/**
+ * Same as {@link createProcessesHarness} but with the pi-processes skill
+ * available, for baseline/candidate comparisons of skill effectiveness.
+ */
+export function createProcessesHarnessWithSkill(
+  name = "processes-extension-with-skill",
+) {
+  return createPiCodingAgentHarness({
+    name,
+    additionalExtensionPaths: [processesExtensionPath],
+    additionalSkillPaths: [processesSkillPath],
+    output: ({ response, session }) => buildOutput(response, session),
+  });
+}
+
+function buildOutput(
+  response: string,
+  session: AgentSession,
+): ProcessEvalOutput {
+  return {
+    response,
+    toolCalls: toolCallsNamed(session, "process"),
+    bashCommands: toolCallsNamed(session, "bash")
+      .map((call) => call.arguments.command)
+      .filter((command): command is string => typeof command === "string"),
+    activeTools: session.getActiveToolNames(),
+  };
+}
+
+/** Every call to `toolName` in the session, in order. */
+function toolCallsNamed(
+  session: AgentSession,
+  toolName: string,
+): ProcessToolCall[] {
+  const calls: ProcessToolCall[] = [];
+  for (const message of session.messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.content) {
+      if (part.type !== "toolCall" || part.name !== toolName) continue;
+      calls.push({
+        name: part.name,
+        arguments: (part.arguments ?? {}) as JsonObject,
+      });
+    }
+  }
+  return calls;
+}
+
+/** `process` calls narrowed to a single action. */
+export function callsWithAction(
+  calls: ProcessToolCall[],
+  action: string,
+): ProcessToolCall[] {
+  return calls.filter((call) => call.arguments.action === action);
+}
+
+/** True when a `process` call declares at least one log watch. */
+export function hasLogMatchWatch(call: ProcessToolCall): boolean {
+  const notify = call.arguments.notify;
+  if (isJsonObject(notify) && Array.isArray(notify.logMatches)) {
+    return notify.logMatches.length > 0;
+  }
+  const watches = call.arguments.watches;
+  if (isJsonObject(watches) && Array.isArray(watches.items)) {
+    return watches.items.length > 0;
+  }
+  return false;
+}
+
+function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/evals/patches/0001-harness-additional-resource-paths.patch
+++ b/tests/evals/patches/0001-harness-additional-resource-paths.patch
@@ -1,0 +1,53 @@
+--- a/pi-harness.ts
++++ b/pi-harness.ts
+@@ -37,6 +37,10 @@
+ 	model?: PiCodingAgentModelSelection;
+ 	noTools?: CreateAgentSessionOptions["noTools"];
+ 	transformSystemPrompt?: (defaultPrompt: string) => string;
++	/** pi-processes patch: load local extensions into the isolated eval session. */
++	additionalExtensionPaths?: string[];
++	/** pi-processes patch: load local skills into the isolated eval session. */
++	additionalSkillPaths?: string[];
+ };
+ 
+ type PiCodingAgentHarnessWithOutput<TOutput extends JsonValue> = PiCodingAgentHarnessOptions & {
+@@ -45,7 +49,7 @@
+ 
+ export function resolveModelSelection(
+ 	explicitModel: PiCodingAgentModelSelection | undefined,
+-	environment: { PI_PROVIDER?: string; PI_MODEL?: string } = process.env,
++	environment: Record<string, string | undefined> = process.env,
+ ): PiCodingAgentModelSelection {
+ 	const provider = (explicitModel?.provider ?? environment.PI_PROVIDER)?.trim();
+ 	const id = (explicitModel?.id ?? environment.PI_MODEL)?.trim();
+@@ -133,9 +137,13 @@
+ 			agentDir,
+ 			modelRuntime,
+ 			settingsManager: SettingsManager.inMemory(),
+-			...(options.transformSystemPrompt
+-				? { resourceLoaderOptions: { systemPromptOverride: () => transformedSystemPrompt } }
+-				: {}),
++			resourceLoaderOptions: {
++				...(options.transformSystemPrompt
++					? { systemPromptOverride: () => transformedSystemPrompt }
++					: {}),
++				...(options.additionalExtensionPaths ? { additionalExtensionPaths: options.additionalExtensionPaths } : {}),
++				...(options.additionalSkillPaths ? { additionalSkillPaths: options.additionalSkillPaths } : {}),
++			},
+ 		});
+ 		signal?.throwIfAborted();
+ 		sessionManager = SessionManager.create(cwd, join(root, "sessions"));
+@@ -163,8 +171,11 @@
+ 		signal?.addEventListener("abort", abort, { once: true });
+ 		try {
+ 			signal?.throwIfAborted();
+-			if (evalSession.extensionRunner.getExtensionPaths().length !== 0) {
+-				throw new Error("Expected an isolated eval session to start without extensions.");
++			const expectedExtensionPaths = options.additionalExtensionPaths?.length ?? 0;
++			if (evalSession.extensionRunner.getExtensionPaths().length !== expectedExtensionPaths) {
++				throw new Error(
++					`Expected the isolated eval session to load exactly ${expectedExtensionPaths} extension(s), got ${evalSession.extensionRunner.getExtensionPaths().length}.`,
++				);
+ 			}
+ 			const steps = typeof input === "string" ? [{ type: "prompt" as const, content: input }] : input;
+ 			let response: string | undefined;

--- a/tests/evals/smoke.eval.ts
+++ b/tests/evals/smoke.eval.ts
@@ -1,0 +1,33 @@
+import { expect } from "vitest";
+import { describeEval } from "vitest-evals";
+
+import { createProcessesHarness } from "./harness";
+
+const harness = createProcessesHarness("smoke");
+
+/**
+ * Cheapest possible end-to-end check of the eval setup itself.
+ *
+ * If this fails, the problem is the harness wiring (vendored pi-evals, model
+ * credentials, extension loading) rather than agent behaviour. Run it first
+ * after every `sync-pi-evals`.
+ *
+ * Deliberately one single-token round trip: the harness already runs with
+ * thinking disabled, the prompt forbids preamble, and both assertions are
+ * checked from that one response. Do not split this into two tests or add
+ * prompts that invite the model to explain itself.
+ */
+describeEval("eval setup smoke", { harness }, (it) => {
+  it("reaches the model with the processes extension loaded", async ({
+    run,
+  }) => {
+    const result = await run("Reply with exactly: ok");
+
+    // Model is reachable and the response round-trips.
+    expect(result.output.response.trim().toLowerCase()).toContain("ok");
+
+    // The patched harness actually injected our extension. This is read from
+    // the session, so it costs nothing beyond the call already made above.
+    expect(result.output.activeTools).toContain("process");
+  });
+});

--- a/tests/evals/tsconfig.json
+++ b/tests/evals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // The vendored pi-evals sources import each other with explicit .ts
+    // extensions. Our own eval files must not (biome forbids it).
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*"],
+  "exclude": ["vendor/**/upstream-package.json"]
+}

--- a/tests/evals/vitest.config.ts
+++ b/tests/evals/vitest.config.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+const evalsDir = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+// Evals resolve models through `ModelRuntime.create()` with no arguments, which
+// reads auth.json/models.json from the agent dir. Force a dedicated dir so runs
+// never depend on (or spend from) the developer's real ~/.pi/agent, and so
+// extension-registered providers are irrelevant.
+const evalAgentDir = `${evalsDir}agent-dir`;
+
+export default defineConfig({
+  // Keep the repo root so CLI path filters stay repo-relative, e.g.
+  // `pnpm test:evals tests/evals/smoke.eval.ts`.
+  root: repoRoot,
+  test: {
+    include: ["tests/evals/**/*.eval.ts"],
+    // Writes tests/evals/agent-dir/models.json from .env.test / the environment.
+    globalSetup: ["./tests/evals/global-setup.ts"],
+    env: {
+      PI_CODING_AGENT_DIR: evalAgentDir,
+      // Pinned here rather than inherited, so an ambient PI_PROVIDER/PI_MODEL
+      // cannot silently redirect evals at a paid account.
+      // Override with PI_EVAL_PROVIDER / PI_EVAL_MODEL.
+      PI_PROVIDER: process.env.PI_EVAL_PROVIDER ?? "aperture",
+      PI_MODEL: process.env.PI_EVAL_MODEL ?? "syn:small:text",
+    },
+    // Evals drive a real model through a real AgentSession: no global mocks,
+    // long timeouts, and low concurrency to stay within provider rate limits.
+    testTimeout: 300_000,
+    hookTimeout: 60_000,
+    maxConcurrency: 1,
+    fileParallelism: false,
+    retry: 0,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,7 @@
     "noEmit": true
   },
   "include": ["src/**/*", "extensions/**/*", "tests/**/*"],
-  "exclude": ["node_modules"]
+  // tests/evals has its own tsconfig: it depends on the gitignored vendored
+  // pi-evals harness, so `pnpm typecheck` must stay green without a sync.
+  "exclude": ["node_modules", "tests/evals"]
 }


### PR DESCRIPTION
Adds behavioral evals for the `process` tool: a real model driven through a real `AgentSession` with the processes extension loaded, asserting on the tool calls it makes.

Only the smoke eval lands here. The behavioral evals (does the agent poll instead of waiting, does it reach for a log watch) will be rewritten from a real failed session.

## Vendored, not installed

`@earendil-works/pi-evals` is `private: true` and unpublished, so it is copied from the pi repo at a pinned tag by `.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh` into `tests/evals/vendor/` (gitignored). CI runs the same script.

A pnpm git dependency (`github:earendil-works/pi#<ref>&path:packages/evals`) does fetch the code, but the harness has to be patched and `pnpm patch` fails on it with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` — it tries to prepare the whole `pi-monorepo` root. Worth revisiting if pi publishes the package.

The patch is load-bearing: upstream's harness deliberately refuses to load extensions (own temp cwd, in-memory settings, forwards `resourceLoaderOptions` only for `transformSystemPrompt`, asserts zero extensions). It adds `additionalExtensionPaths`/`additionalSkillPaths` and relaxes the guard to expect exactly the injected extensions, plus widens one `process.env` parameter `@types/node` 25 rejects.

## Secrets

The Aperture base URL is private and `models.json` has no env interpolation, so `global-setup.ts` generates the whole file at run time from `.env.test` (Node's `loadEnvFile`). The entire `agent-dir/` is gitignored. A real `APERTURE_BASE_URL` wins over the file, which is how CI injects it. Verified no committed file contains the URL.

## CI

Evals cost money, so the job is gated twice: `workflow_dispatch` only **and** a `run_evals` input defaulting to false. Push and PR cannot reach it. The existing `check` job is untouched.

Tailscale auth uses workload identity federation (OIDC), so no long-lived Tailscale secret is stored: the runner requests a GitHub OIDC token and exchanges it for a short-lived API token. Needs `permissions: id-token: write`, which is set on the job.

Requires before it can run: secrets `TS_OAUTH_CLIENT_ID` (federated identity Client ID), `TS_AUDIENCE`, `APERTURE_BASE_URL`, `APERTURE_API_KEY`; a Trust credential in the Tailscale admin console with the writable `auth_keys` scope, issuer GitHub Actions, and a subject matching this repo; and `tag:ci-evals` authorized for that credential with ACL access to the Aperture host. `workflow_dispatch` also only appears in the Actions UI once this is on the default branch.

## Verifying

```bash
./.agents/skills/sync-pi-evals/scripts/sync-pi-evals.sh
cp .env.test.example .env.test   # fill in APERTURE_BASE_URL
pnpm typecheck:evals             # free
pnpm test:evals                  # one short model call
```

Checked from a clean slate: sync, lint, `typecheck`, `typecheck:evals`, 590 unit tests, and the smoke eval all pass. The smoke eval was verified in both directions — breaking the extension path fails with `Expected the isolated eval session to load exactly 1 extension(s), got 0` rather than silently passing.

